### PR TITLE
Update chainguard images to use digests.

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -21,7 +21,7 @@ services:
       retries: 3
       start_period: 3s
       timeout: 3s
- 
+
   backend:
     image: gradle:7-jdk17
     user: ${MY_UID}:${MY_GID}
@@ -53,7 +53,7 @@ services:
       retries: 10
       start_period: 60s
       timeout: 3s
-  
+
   frontend:
     image: neuris/frontend
     extra_hosts:
@@ -97,7 +97,7 @@ services:
       timeout: 3s
 
   redis:
-    image: cgr.dev/chainguard/redis:7.0
+    image: cgr.dev/chainguard/redis:7.0@sha256:304aca7d02274ec04ffe6e6e9fe19da1c42d2c3e062ba35183290010b93feb8e
     extra_hosts:
       - localhost:host-gateway
     container_name: redis

--- a/frontend/Dockerfile.prod
+++ b/frontend/Dockerfile.prod
@@ -3,7 +3,7 @@ WORKDIR /usr/src/app
 COPY . .
 RUN npm install && npx vite build
 
-FROM cgr.dev/chainguard/nginx:1.25
+FROM cgr.dev/chainguard/nginx:1.25@sha256:5426bfb328fd8c38412fcdd48e474918e0d17058d0b9cc1cdbefd38476c06f65
 EXPOSE 8081
 COPY --from=builder /usr/src/app/dist /var/lib/nginx/html
 COPY nginx.conf /etc/nginx/conf.d/ris.conf


### PR DESCRIPTION
We're making some changes to the public tier of Chainguard Images.

Starting August 16, 2023 public users will no longer be able to pull images from our registry (cgr.dev/chainguard) by tags other than latest or latest-dev. Please see [the announcement](https://www.chainguard.dev/unchained/scaling-chainguard-images-with-a-growing-catalog-and-proactive-security-updates) for more information.

This PR will move your images to use digests that will continue to work post August 16th.

Please see [the migration guide](https://www.chainguard.dev/unchained/a-guide-on-how-to-use-chainguard-images-for-public-catalog-tier-users) for full details on your options.