### PR TITLE
Refactor: rework chips components

### DIFF
--- a/frontend/src/components/KeyWords.vue
+++ b/frontend/src/components/KeyWords.vue
@@ -71,8 +71,8 @@ watch(
           aria-label="Schlagwörter"
           :error="errorMessage"
           :model-value="keywords"
-          @add-chip="addKeyword"
-          @delete-chip="deleteKeyword"
+          @chip-added="addKeyword"
+          @chip-deleted="deleteKeyword"
         ></KeywordsChipsInput>
       </div>
     </div>

--- a/frontend/src/components/documentStatus/DocumentStatusInputGroup.vue
+++ b/frontend/src/components/documentStatus/DocumentStatusInputGroup.vue
@@ -33,7 +33,7 @@ watch(inputValue, () => emit("update:modelValue", inputValue.value), {
 
 const workNote = computed({
   get: () => inputValue.value.WORK_NOTE,
-  set: (data?: string[]) => data && (inputValue.value.WORK_NOTE = data),
+  set: (data?: string[]) => (inputValue.value.WORK_NOTE = data),
 })
 
 const description = computed({

--- a/frontend/src/components/documentType/DocumentTypeInputGroup.vue
+++ b/frontend/src/components/documentType/DocumentTypeInputGroup.vue
@@ -53,7 +53,7 @@ watch(
 
 const templateName = computed({
   get: () => inputValue.value.TEMPLATE_NAME,
-  set: (data?: string[]) => data && (inputValue.value.TEMPLATE_NAME = data),
+  set: (data?: string[]) => (inputValue.value.TEMPLATE_NAME = data),
 })
 
 const NORM_CATEGORY_NAMES = {

--- a/frontend/src/routes/kitchensink/index/chips.vue
+++ b/frontend/src/routes/kitchensink/index/chips.vue
@@ -19,8 +19,8 @@ const dateChips = ref<ChipsInputModelType>(["2023-07-20", "2023-07-21"])
       <InputField id="inlineChipsInput" v-slot="{ id }" label="Inline chips">
         <ChipsInput
           :id="id"
+          v-model="inlineChips"
           aria-label="Inline chips input"
-          :model-value="inlineChips"
         />
       </InputField>
     </KitchensinkStory>
@@ -29,8 +29,8 @@ const dateChips = ref<ChipsInputModelType>(["2023-07-20", "2023-07-21"])
       <InputField id="stackedChipsInput" v-slot="{ id }" label="Stacked chips">
         <ChipsInputBottom
           :id="id"
+          v-model="stackedChips"
           aria-label="Stacked chips input"
-          :model-value="stackedChips"
         />
       </InputField>
     </KitchensinkStory>
@@ -39,8 +39,8 @@ const dateChips = ref<ChipsInputModelType>(["2023-07-20", "2023-07-21"])
       <InputField id="dateChipsInput" v-slot="{ id }" label="Date chips">
         <ChipsDateInput
           :id="id"
+          v-model="dateChips"
           aria-label="Date chips input"
-          :model-value="dateChips"
         />
       </InputField>
     </KitchensinkStory>

--- a/frontend/src/shared/components/input/TextInput.vue
+++ b/frontend/src/shared/components/input/TextInput.vue
@@ -45,7 +45,7 @@ function focusInput() {
   inputRef.value?.focus()
 }
 
-defineExpose({ focusInput })
+defineExpose({ focusInput, inputRef })
 </script>
 
 <template>

--- a/frontend/test/components/documentType/documentTypeInputGroup.spec.ts
+++ b/frontend/test/components/documentType/documentTypeInputGroup.spec.ts
@@ -167,6 +167,6 @@ describe("DocumentTypeInputGroup", () => {
     await user.type(chipList[0], "{enter}")
     await user.click(chipList[0])
     await user.type(chipList[0], "{enter}")
-    expect(modelValue.TEMPLATE_NAME).toHaveLength(0)
+    expect(modelValue.TEMPLATE_NAME).toBeUndefined()
   })
 })

--- a/frontend/test/components/keywordsChipsInput.spec.ts
+++ b/frontend/test/components/keywordsChipsInput.spec.ts
@@ -1,28 +1,30 @@
 import userEvent from "@testing-library/user-event"
 import { render, screen } from "@testing-library/vue"
-import ChipsInput from "@/shared/components/input/ChipsInput.vue"
+import KeywordsChipsInput from "@/shared/components/input/KeywordsChipsInput.vue"
 
-type ChipsInputProps = InstanceType<typeof ChipsInput>["$props"]
+type KeywordsChipsInputProps = InstanceType<typeof KeywordsChipsInput>["$props"]
 
-function renderComponent(props?: Partial<ChipsInputProps>) {
+function renderComponent(props?: Partial<KeywordsChipsInputProps>) {
   const user = userEvent.setup()
 
   let modelValue: string[] | undefined = props?.modelValue ?? []
 
-  const effectiveProps: ChipsInputProps = {
+  const effectiveProps: KeywordsChipsInputProps = {
     id: props?.id ?? "identifier",
     modelValue,
     "onUpdate:modelValue":
       props?.["onUpdate:modelValue"] ?? ((val) => (modelValue = val)),
     ariaLabel: props?.ariaLabel ?? "aria-label",
+    validationError: props?.validationError,
     onChipAdded: props?.onChipAdded,
     onChipDeleted: props?.onChipDeleted,
+    error: props?.error,
   }
 
-  return { user, ...render(ChipsInput, { props: effectiveProps }) }
+  return { user, ...render(KeywordsChipsInput, { props: effectiveProps }) }
 }
 
-describe("Chips Input", () => {
+describe("Keywords Chips Input", () => {
   it("shows a chips input element", () => {
     renderComponent()
     const input = screen.getByRole<HTMLInputElement>("textbox")
@@ -81,6 +83,28 @@ describe("Chips Input", () => {
     expect(input).toHaveValue("")
   })
 
+  it("does not add a chip when input is empty", async () => {
+    const onUpdate = vi.fn()
+    const { user } = renderComponent({ "onUpdate:modelValue": onUpdate })
+    const input = screen.getByRole<HTMLInputElement>("textbox")
+    expect(input).toHaveValue("")
+
+    await user.type(input, "{enter}")
+
+    expect(onUpdate).not.toHaveBeenCalled()
+  })
+
+  it("does not add a chip when input is only whitespaces", async () => {
+    const onUpdate = vi.fn()
+    const { user } = renderComponent({ "onUpdate:modelValue": onUpdate })
+    const input = screen.getByRole<HTMLInputElement>("textbox")
+    expect(input).toHaveValue("")
+
+    await user.type(input, "   {enter}")
+
+    expect(onUpdate).not.toHaveBeenCalled()
+  })
+
   it("emits model update when a chip is removed", async () => {
     const onUpdate = vi.fn()
     const { user } = renderComponent({
@@ -105,79 +129,26 @@ describe("Chips Input", () => {
     expect(onDeleted).toHaveBeenCalledWith("foo")
   })
 
-  it("does not add a chip when input is empty", async () => {
-    const onUpdate = vi.fn()
-    const { user } = renderComponent({ "onUpdate:modelValue": onUpdate })
-    const input = screen.getByRole<HTMLInputElement>("textbox")
-    expect(input).toHaveValue("")
-
-    await user.type(input, "{enter}")
-
-    expect(onUpdate).not.toHaveBeenCalled()
-  })
-
-  it("does not add a chip when input is only whitespaces", async () => {
-    const onUpdate = vi.fn()
-    const { user } = renderComponent({ "onUpdate:modelValue": onUpdate })
-    const input = screen.getByRole<HTMLInputElement>("textbox")
-    expect(input).toHaveValue("")
-
-    await user.type(input, "   {enter}")
-
-    expect(onUpdate).not.toHaveBeenCalled()
-  })
-
-  it("focuses the input when clicking on the chips component", async () => {
-    const { user } = renderComponent({ id: "test" })
-
-    const chips = screen.getByTestId("chips-input_test")
-    await user.click(chips)
-
-    const input = screen.getByRole<HTMLInputElement>("textbox")
-    expect(input).toHaveFocus()
-  })
-
-  it("focuses the input when the last chip is deleted", async () => {
-    let modelValue: ChipsInputProps["modelValue"] = ["foo", "bar"]
-    const onUpdate: ChipsInputProps["onUpdate:modelValue"] = (val) => {
-      modelValue = val
-    }
-    const { user, rerender } = renderComponent({
-      modelValue,
-      "onUpdate:modelValue": onUpdate,
-    })
-
-    const deleteButtons = screen.getAllByRole("button")
-    await user.click(deleteButtons[1])
-    await rerender({ modelValue })
-    await user.click(deleteButtons[0])
-    await rerender({ modelValue })
-
-    const input = screen.getByRole<HTMLInputElement>("textbox")
-    expect(input).toHaveFocus()
-  })
-
-  it("focuses the input when pressing arrow on the last chip", async () => {
+  it("focuses the input when pressing arrow on the first chip", async () => {
     const { user } = renderComponent({ modelValue: ["foo", "bar", "baz"] })
 
     const chips = screen.getAllByRole("listitem")
-    await user.click(chips[2])
-    await user.keyboard("{arrowright}")
+    await user.click(chips[0])
+    await user.keyboard("{arrowleft}")
     const input = screen.getByRole<HTMLInputElement>("textbox")
     expect(input).toHaveFocus()
   })
 
-  it("focuses the last chip when pressing arrow on the input", async () => {
+  it("focuses the first chip when pressing arrow on the input", async () => {
     const { user } = renderComponent({ modelValue: ["foo", "bar", "baz"] })
 
     const input = screen.getByRole<HTMLInputElement>("textbox")
     await user.click(input)
     await user.type(input, "abc")
-    await user.keyboard("{arrowleft}{arrowleft}{arrowleft}")
     expect(input).toHaveFocus()
-    await user.keyboard("{arrowleft}")
+    await user.keyboard("{arrowright}")
     const chips = screen.getAllByRole("listitem")
-    expect(chips[2]).toHaveFocus()
+    expect(chips[0]).toHaveFocus()
   })
 
   it("focuses chips with arrow keys", async () => {
@@ -185,21 +156,21 @@ describe("Chips Input", () => {
 
     const input = screen.getByRole<HTMLInputElement>("textbox")
     await user.click(input)
-    await user.tab({ shift: true })
+    await user.tab()
 
     const chips = screen.getAllByRole("listitem")
-    expect(chips[2]).toHaveFocus()
-    await user.keyboard("{arrowleft}")
-    expect(chips[1]).toHaveFocus()
-    await user.keyboard("{arrowleft}")
-    expect(chips[0]).toHaveFocus()
-    await user.keyboard("{arrowleft}")
     expect(chips[0]).toHaveFocus()
     await user.keyboard("{arrowright}")
     expect(chips[1]).toHaveFocus()
     await user.keyboard("{arrowright}")
     expect(chips[2]).toHaveFocus()
     await user.keyboard("{arrowright}")
+    expect(chips[2]).toHaveFocus()
+    await user.keyboard("{arrowleft}")
+    expect(chips[1]).toHaveFocus()
+    await user.keyboard("{arrowleft}")
+    expect(chips[0]).toHaveFocus()
+    await user.keyboard("{arrowleft}")
     expect(input).toHaveFocus()
   })
 
@@ -208,11 +179,11 @@ describe("Chips Input", () => {
 
     const input = screen.getByRole<HTMLInputElement>("textbox")
     await user.click(input)
-    await user.tab({ shift: true })
+    await user.tab()
 
     const chips = screen.getAllByRole("listitem")
-    expect(chips[2]).toHaveFocus()
-    await user.tab()
+    expect(chips[0]).toHaveFocus()
+    await user.tab({ shift: true })
     expect(input).toHaveFocus()
   })
 
@@ -227,5 +198,43 @@ describe("Chips Input", () => {
     await user.click(chips[1])
     await user.keyboard("{enter}")
     expect(onUpdate).toHaveBeenCalledWith(["foo"])
+  })
+
+  it("shows an error message", () => {
+    renderComponent({ error: { title: "foo" } })
+    expect(screen.getByText("foo")).toBeInTheDocument()
+  })
+
+  it("clears the error message on blur", async () => {
+    const { user } = renderComponent({ error: { title: "foo" } })
+    expect(screen.getByText("foo")).toBeInTheDocument()
+
+    const input = screen.getByRole("textbox")
+    await user.click(input)
+    await user.tab()
+    expect(screen.queryByText("foo")).not.toBeInTheDocument()
+  })
+
+  it("clears the error message on input", async () => {
+    const { user } = renderComponent({ error: { title: "foo" } })
+    expect(screen.getByText("foo")).toBeInTheDocument()
+
+    const input = screen.getByRole("textbox")
+    await user.click(input)
+    await user.type(input, "o")
+    expect(screen.queryByText("foo")).not.toBeInTheDocument()
+  })
+
+  it("shows an error message when adding a chip that already exists", async () => {
+    const onUpdate = vi.fn()
+    const { user } = renderComponent({
+      modelValue: ["one"],
+      "onUpdate:modelValue": onUpdate,
+    })
+
+    const input = screen.getByRole<HTMLInputElement>("textbox")
+    await user.type(input, "one{enter}")
+    expect(screen.getByText("Schlagwort bereits vergeben.")).toBeInTheDocument()
+    expect(onUpdate).not.toHaveBeenCalled()
   })
 })

--- a/frontend/test/components/officialReference/digitalAnnouncementInputGroup.spec.ts
+++ b/frontend/test/components/officialReference/digitalAnnouncementInputGroup.spec.ts
@@ -298,15 +298,15 @@ describe("DigitalAnnouncementInputGroup", () => {
     )
 
     for (const chip of additionalInfoChips) {
-      const clearButton = within(chip).getByLabelText("Löschen")
+      const clearButton = within(chip).getByRole("button")
       await user.click(clearButton)
     }
-    expect(modelValue.ADDITIONAL_INFO).toStrictEqual([])
+    expect(modelValue.ADDITIONAL_INFO).toBeUndefined()
 
     for (const chip of explanationChips) {
-      const clearButton = within(chip).getByLabelText("Löschen")
+      const clearButton = within(chip).getByRole("button")
       await user.click(clearButton)
     }
-    expect(modelValue.EXPLANATION).toStrictEqual([])
+    expect(modelValue.EXPLANATION).toBeUndefined()
   })
 })

--- a/frontend/test/components/officialReference/euAnnouncementInputGroup.spec.ts
+++ b/frontend/test/components/officialReference/euAnnouncementInputGroup.spec.ts
@@ -232,15 +232,15 @@ describe("EuGovernmentGazetteInputGroup", () => {
     expect(modelValue.PAGE).toBeUndefined()
 
     for (const chip of additionalInfoChips) {
-      const clearButton = within(chip).getByLabelText("Löschen")
+      const clearButton = within(chip).getByRole("button")
       await user.click(clearButton)
     }
-    expect(modelValue.ADDITIONAL_INFO).toStrictEqual([])
+    expect(modelValue.ADDITIONAL_INFO).toBeUndefined()
 
     for (const chip of explanationChips) {
-      const clearButton = within(chip).getByLabelText("Löschen")
+      const clearButton = within(chip).getByRole("button")
       await user.click(clearButton)
     }
-    expect(modelValue.EXPLANATION).toStrictEqual([])
+    expect(modelValue.EXPLANATION).toBeUndefined()
   })
 })

--- a/frontend/test/components/officialReference/printAnnouncementInputGroup.spec.ts
+++ b/frontend/test/components/officialReference/printAnnouncementInputGroup.spec.ts
@@ -216,15 +216,15 @@ describe("PrintAnnouncementInputGroup", () => {
     expect(modelValue.PAGE).toBeUndefined()
 
     for (const chip of additionalInfoChips) {
-      const clearButton = within(chip).getByLabelText("Löschen")
+      const clearButton = within(chip).getByRole("button")
       await user.click(clearButton)
     }
-    expect(modelValue.ADDITIONAL_INFO).toStrictEqual([])
+    expect(modelValue.ADDITIONAL_INFO).toBeUndefined()
 
     for (const chip of explanationChips) {
-      const clearButton = within(chip).getByLabelText("Löschen")
+      const clearButton = within(chip).getByRole("button")
       await user.click(clearButton)
     }
-    expect(modelValue.EXPLANATION).toStrictEqual([])
+    expect(modelValue.EXPLANATION).toBeUndefined()
   })
 })

--- a/frontend/test/components/statusIndication/UpdateStatusIndicationGroup.spec.ts
+++ b/frontend/test/components/statusIndication/UpdateStatusIndicationGroup.spec.ts
@@ -125,7 +125,7 @@ describe("UpdateStatusIndicationGroup in status mode", () => {
     await user.type(references[0], "{enter}")
     await user.click(references[0])
     await user.type(references[0], "{enter}")
-    expect(modelValue.REFERENCE).toHaveLength(0)
+    expect(modelValue.REFERENCE).toBeUndefined()
   })
 })
 

--- a/frontend/test/e2e/caselaw/categories/coreData/court.spec.ts
+++ b/frontend/test/e2e/caselaw/categories/coreData/court.spec.ts
@@ -90,7 +90,7 @@ test.describe("court", () => {
         await expect(page.locator("text=IncorrectCourt2")).toBeVisible()
 
         await page
-          .locator(":text('IncorrectCourt1') + div > [aria-label='Löschen']")
+          .locator(":text('IncorrectCourt1') + button[aria-label='Löschen']")
           .click()
       },
       page,


### PR DESCRIPTION
This affects:

- Chips list
- Chips input
- Keywords chips

These use shared logic and very similar in terms of implementation and interaction (even though there are some layout and requirement details that make it more convenient to keep them separate). Note that the date chips input is not affected, since it's completely separate from the others.

This commit:

- Changes the list and chips v-models to be immutable according to the new immutable v-model pattern (see ADR 15)
- Also refactors the focus handling to be a v-model to make it easier to use and less verbose
- Fixes a bunch of bugs in the chips and components using the chips along the way
- Improves test coverage for all 3 components, splits the tests for keywords and regular chips into 2 files

RISDEV-2038