### PR TITLE
RISDEV-3406: Cleanup documentation units in e2e

### DIFF
--- a/frontend/test/e2e/caselaw/categories/coreData/core-data.spec.ts
+++ b/frontend/test/e2e/caselaw/categories/coreData/core-data.spec.ts
@@ -1,5 +1,9 @@
 import { expect } from "@playwright/test"
-import { navigateToCategories, waitForSaving } from "../../e2e-utils"
+import {
+  deleteDocumentUnit,
+  navigateToCategories,
+  waitForSaving,
+} from "../../e2e-utils"
 import { caselawTest as test } from "../../fixtures"
 
 test.describe("core data", () => {
@@ -246,6 +250,12 @@ test.describe("core data", () => {
 
       await page.getByText("Rubriken").click()
       await expect(page.getByText("DOKUMENTATIONSSTELLEDS")).toBeVisible()
+
+      const documentNumber = page
+        .url()
+        .match(/documentunit\/([A-Z0-9]{13})\/files/)![1]
+
+      await deleteDocumentUnit(page, documentNumber)
     })
   })
 
@@ -269,6 +279,12 @@ test.describe("core data", () => {
       await expect(
         pageWithBghUser.getByText("DOKUMENTATIONSSTELLEBGH"),
       ).toBeVisible()
+
+      const documentNumber = pageWithBghUser
+        .url()
+        .match(/documentunit\/([A-Z0-9]{13})\/files/)![1]
+
+      await deleteDocumentUnit(pageWithBghUser, documentNumber)
     })
   })
 

--- a/frontend/test/e2e/caselaw/categories/editableLists/relatedDocumentations/previous-decisions.spec.ts
+++ b/frontend/test/e2e/caselaw/categories/editableLists/relatedDocumentations/previous-decisions.spec.ts
@@ -217,5 +217,19 @@ test.describe("previous decisions", () => {
         `AG Aachen, 31.12.2019, ${prefilledDocumentUnit.coreData.fileNumbers?.[0]}, ${deviatingFileNumber1}, Anerkenntnisurteil`,
       ),
     ).toBeVisible()
+
+    // Clean up:
+    // We need to unlink the document units in order to be allowed to delete them in the fixtures
+    await previousDecisionContainer.getByLabel("Listen Eintrag").click()
+    await page
+      .getByLabel("Abweichendes Aktenzeichen Vorgehende Entscheidung", {
+        exact: true,
+      })
+      .clear()
+
+    await previousDecisionContainer.getByLabel("Eintrag löschen").click()
+
+    await page.getByText("Speichern").click()
+    await page.waitForEvent("requestfinished")
   })
 })

--- a/frontend/test/e2e/caselaw/documentunit-search.spec.ts
+++ b/frontend/test/e2e/caselaw/documentunit-search.spec.ts
@@ -1,6 +1,10 @@
 import { expect } from "@playwright/test"
 import dayjs from "dayjs"
-import { fillSearchInput, navigateToSearch } from "~/e2e/caselaw/e2e-utils"
+import {
+  deleteDocumentUnit,
+  fillSearchInput,
+  navigateToSearch,
+} from "~/e2e/caselaw/e2e-utils"
 import { caselawTest as test } from "~/e2e/caselaw/fixtures"
 import { generateString } from "~/test-helper/dataGenerators"
 
@@ -518,7 +522,6 @@ test.describe("search", () => {
 
   test("create new doc unit from search parameter and switch to categories page", async ({
     page,
-    request,
   }) => {
     await navigateToSearch(page)
 
@@ -567,11 +570,7 @@ test.describe("search", () => {
       infoPanel.getByText(`Entscheidungsdatum${decisionDate}`),
     ).toBeVisible()
 
-    // Clean up
-    const response = await (
-      await request.get(`api/v1/caselaw/documentunits/${documentNumber}`)
-    ).json()
-    await request.delete(`/api/v1/caselaw/documentunits/${response.uuid}`)
+    await deleteDocumentUnit(page, documentNumber)
   })
 
   test("show error message when creating new doc unit from search parameters fails", async ({

--- a/frontend/test/e2e/caselaw/e2e-utils.ts
+++ b/frontend/test/e2e/caselaw/e2e-utils.ts
@@ -100,10 +100,17 @@ export async function toggleFieldOfLawSection(page: Page): Promise<void> {
 }
 
 export async function deleteDocumentUnit(page: Page, documentNumber: string) {
-  const response = await page.request.delete(
+  const getResponse = await page.request.get(
     `/api/v1/caselaw/documentunits/${documentNumber}`,
   )
-  expect(response.ok).toBeTruthy()
+  expect(getResponse.ok()).toBeTruthy()
+
+  const { uuid } = await getResponse.json()
+
+  const deleteResponse = await page.request.delete(
+    `/api/v1/caselaw/documentunits/${uuid}`,
+  )
+  expect(deleteResponse.ok()).toBeTruthy()
 }
 
 export async function documentUnitExists(

--- a/frontend/test/e2e/caselaw/fixtures.ts
+++ b/frontend/test/e2e/caselaw/fixtures.ts
@@ -23,12 +23,20 @@ export const caselawTest = test.extend<MyFixtures>({
 
     await use(documentNumber)
 
-    await request.delete(`/api/v1/caselaw/documentunits/${uuid}`)
+    const deleteResponse = await request.delete(
+      `/api/v1/caselaw/documentunits/${uuid}`,
+    )
+
+    if (!deleteResponse.ok()) {
+      throw Error(`DocumentUnit with number ${documentNumber} couldn't be deleted:
+      ${deleteResponse.status()} ${deleteResponse.statusText()}`)
+    }
   },
 
   prefilledDocumentUnit: async ({ request }, use) => {
     const response = await request.get(`/api/v1/caselaw/documentunits/new`)
     const prefilledDocumentUnit = await response.json()
+    const { documentNumber } = await response.json()
 
     const courtResponse = await request.get(`api/v1/caselaw/courts?q=AG+Aachen`)
     const court = await courtResponse.json()
@@ -61,14 +69,19 @@ export const caselawTest = test.extend<MyFixtures>({
 
     await use(await updateResponse.json())
 
-    await request.delete(
+    const deleteResponse = await request.delete(
       `/api/v1/caselaw/documentunits/${prefilledDocumentUnit.uuid}`,
     )
+    if (!deleteResponse.ok()) {
+      throw Error(`DocumentUnit with number ${documentNumber} couldn't be deleted:
+      ${deleteResponse.status()} ${deleteResponse.statusText()}`)
+    }
   },
 
   secondPrefilledDocumentUnit: async ({ request }, use) => {
     const response = await request.get(`/api/v1/caselaw/documentunits/new`)
     const secondPrefilledDocumentUnit = await response.json()
+    const { documentNumber } = await response.json()
 
     const courtResponse = await request.get(`api/v1/caselaw/courts?q=AG+Aachen`)
     const court = await courtResponse.json()
@@ -96,9 +109,13 @@ export const caselawTest = test.extend<MyFixtures>({
 
     await use(await updateResponse.json())
 
-    await request.delete(
+    const deleteResponse = await request.delete(
       `/api/v1/caselaw/documentunits/${secondPrefilledDocumentUnit.uuid}`,
     )
+    if (!deleteResponse.ok()) {
+      throw Error(`DocumentUnit with number ${documentNumber} couldn't be deleted:
+      ${deleteResponse.status()} ${deleteResponse.statusText()}`)
+    }
   },
 
   editorField: async ({ page, documentNumber }, use) => {


### PR DESCRIPTION
Context: 
We currently don't clean up all documentation units we create in the e2e. With this commit we have no uncleared documents left. 

RISDEV-3406