### PR TITLE
Fix Mangel: Allow special characters in normen search

### DIFF
--- a/backend/src/main/java/de/bund/digitalservice/ris/caselaw/adapter/database/jpa/DatabaseNormAbbreviationRepository.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/caselaw/adapter/database/jpa/DatabaseNormAbbreviationRepository.java
@@ -42,9 +42,9 @@ public interface DatabaseNormAbbreviationRepository
               + " official_short_title,"
               + " source,"
               + " region_id,"
-              + " ts_rank_cd(weighted_vector, to_tsquery('german', '' || :tsQuery || '')) rank"
+              + " ts_rank_cd(weighted_vector, plainto_tsquery('german', '' || :tsQuery || '')) rank"
               + " from incremental_migration.norm_abbreviation_search_migration"
-              + " where weighted_vector @@ to_tsquery('german', '' || :tsQuery || '')"
+              + " where weighted_vector @@ plainto_tsquery('german', '' || :tsQuery || '')"
               + " order by rank desc"
               + " limit :size"
               + " offset :offset",

--- a/backend/src/test/java/de/bund/digitalservice/ris/caselaw/integration/tests/NormAbbreviationIntegrationTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/caselaw/integration/tests/NormAbbreviationIntegrationTest.java
@@ -133,6 +133,19 @@ class NormAbbreviationIntegrationTest {
           .officialShortTitle("official short title 7")
           .source("Y")
           .build();
+
+  private NormAbbreviationDTO abbreviationWithSpecialCharacters =
+      NormAbbreviationDTO.builder()
+          .abbreviation("With special / characters ;+-*:()")
+          .decisionDate(LocalDate.of(2023, Month.MAY, 25))
+          .documentId(7891L)
+          .documentNumber("document number 8")
+          .officialLetterAbbreviation("official letter abbreviation 8")
+          .officialLongTitle("official long title 8")
+          .officialShortTitle("official short title 8")
+          .source("Z")
+          .build();
+
   private DocumentCategoryDTO documentCategoryDTO1 =
       DocumentCategoryDTO.builder().label("L").build();
   private DocumentCategoryDTO documentCategoryDTO2 =
@@ -382,6 +395,29 @@ class NormAbbreviationIntegrationTest {
   }
 
   @Test
+  void testGetNormAbbreviationBySearchQuery_allowSpecialCharacters() {
+    generateLookupValues();
+    repository.refreshMaterializedViews();
+
+    String query = "With special / characters ;";
+
+    risWebTestClient
+        .withDefaultLogin()
+        .get()
+        .uri("/api/v1/caselaw/normabbreviation/search?pg=0&sz=30&q=" + query)
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectBody(NormAbbreviation[].class)
+        .consumeWith(
+            response -> {
+              assertThat(response.getResponseBody())
+                  .extracting("id")
+                  .containsExactly(abbreviationWithSpecialCharacters.getId());
+            });
+  }
+
+  @Test
   void testGetNormAbbreviationByAwesomeSearchQuery_returnInTheRightOrder() {
     generateLookupValues();
     repository.refreshMaterializedViews();
@@ -443,6 +479,7 @@ class NormAbbreviationIntegrationTest {
     abbreviation5 = repository.save(abbreviation5);
     abbreviation6 = repository.save(abbreviation6);
     abbreviation7 = repository.save(abbreviation7);
+    abbreviationWithSpecialCharacters = repository.save(abbreviationWithSpecialCharacters);
   }
 
   private class NormAbbreviationTestBuilder {


### PR DESCRIPTION
RISDEV-3133

We have the issue that special characters are thrown away in the query and therefore the search results are empty when inserting them into the search. I tried to solve this issue by using the plaintto_tsquery feature by [postrgresql](https://www.postgresql.org/docs/current/textsearch-controls.html#TEXTSEARCH-PARSING-QUERIES)