### PR TITLE
Improve style for buttons

### DIFF
--- a/frontend/src/components/ActiveCitationInput.vue
+++ b/frontend/src/components/ActiveCitationInput.vue
@@ -266,12 +266,11 @@ onBeforeUnmount(() => {
     </div>
     <div class="flex w-full flex-row justify-between">
       <div>
-        <div>
+        <div class="flex gap-16">
           <TextButton
             v-if="!activeCitation.hasForeignSource"
             aria-label="Nach Entscheidung suchen"
             button-type="primary"
-            class="mr-16"
             label="Suchen"
             size="small"
             @click="search"
@@ -279,7 +278,6 @@ onBeforeUnmount(() => {
           <TextButton
             aria-label="Aktivzitierung speichern"
             button-type="tertiary"
-            class="mr-16"
             :disabled="activeCitation.isEmpty"
             label="Übernehmen"
             size="small"

--- a/frontend/src/components/ActiveCitationInput.vue
+++ b/frontend/src/components/ActiveCitationInput.vue
@@ -271,7 +271,7 @@ onBeforeUnmount(() => {
             v-if="!activeCitation.hasForeignSource"
             aria-label="Nach Entscheidung suchen"
             button-type="primary"
-            class="mr-24"
+            class="mr-16"
             label="Suchen"
             size="small"
             @click="search"
@@ -279,7 +279,7 @@ onBeforeUnmount(() => {
           <TextButton
             aria-label="Aktivzitierung speichern"
             button-type="tertiary"
-            class="mr-24"
+            class="mr-16"
             :disabled="activeCitation.isEmpty"
             label="Übernehmen"
             size="small"

--- a/frontend/src/components/EnsuingDecisionInputGroup.vue
+++ b/frontend/src/components/EnsuingDecisionInputGroup.vue
@@ -271,7 +271,7 @@ onBeforeUnmount(() => {
             v-if="!ensuingDecision.hasForeignSource"
             aria-label="Nach Entscheidung suchen"
             button-type="primary"
-            class="mr-24"
+            class="mr-16"
             label="Suchen"
             size="small"
             @click="search"
@@ -279,7 +279,7 @@ onBeforeUnmount(() => {
           <TextButton
             aria-label="Nachgehende Entscheidung speichern"
             button-type="tertiary"
-            class="mr-24"
+            class="mr-16"
             :disabled="ensuingDecision.isEmpty"
             label="Übernehmen"
             size="small"

--- a/frontend/src/components/EnsuingDecisionInputGroup.vue
+++ b/frontend/src/components/EnsuingDecisionInputGroup.vue
@@ -266,12 +266,11 @@ onBeforeUnmount(() => {
 
     <div class="flex w-full flex-row justify-between">
       <div>
-        <div>
+        <div class="flex gap-16">
           <TextButton
             v-if="!ensuingDecision.hasForeignSource"
             aria-label="Nach Entscheidung suchen"
             button-type="primary"
-            class="mr-16"
             label="Suchen"
             size="small"
             @click="search"
@@ -279,7 +278,6 @@ onBeforeUnmount(() => {
           <TextButton
             aria-label="Nachgehende Entscheidung speichern"
             button-type="tertiary"
-            class="mr-16"
             :disabled="ensuingDecision.isEmpty"
             label="Übernehmen"
             size="small"

--- a/frontend/src/components/NormReferenceInput.vue
+++ b/frontend/src/components/NormReferenceInput.vue
@@ -177,11 +177,10 @@ onBeforeUnmount(() => {
     </div>
     <div class="flex w-full flex-row justify-between">
       <div>
-        <div class="flex">
+        <div class="flex gap-16">
           <TextButton
             aria-label="Weitere Einzelnorm"
             button-type="tertiary"
-            class="mr-16"
             :disabled="!norm.singleNorm"
             :icon="IconAdd"
             label="Weitere Einzelnorm"
@@ -190,7 +189,6 @@ onBeforeUnmount(() => {
           <TextButton
             aria-label="Norm speichern"
             button-type="primary"
-            class="mr-16"
             :disabled="norm.isEmpty"
             label="Übernehmen"
             size="small"

--- a/frontend/src/components/NormReferenceInput.vue
+++ b/frontend/src/components/NormReferenceInput.vue
@@ -177,10 +177,11 @@ onBeforeUnmount(() => {
     </div>
     <div class="flex w-full flex-row justify-between">
       <div>
-        <div class="flex gap-24">
+        <div class="flex">
           <TextButton
             aria-label="Weitere Einzelnorm"
             button-type="tertiary"
+            class="mr-16"
             :disabled="!norm.singleNorm"
             :icon="IconAdd"
             label="Weitere Einzelnorm"
@@ -189,6 +190,7 @@ onBeforeUnmount(() => {
           <TextButton
             aria-label="Norm speichern"
             button-type="primary"
+            class="mr-16"
             :disabled="norm.isEmpty"
             label="Übernehmen"
             size="small"

--- a/frontend/src/components/PreviousDecisionInputGroup.vue
+++ b/frontend/src/components/PreviousDecisionInputGroup.vue
@@ -277,12 +277,11 @@ onBeforeUnmount(() => {
     </div>
     <div class="flex w-full flex-row justify-between">
       <div>
-        <div>
+        <div class="flex gap-16">
           <TextButton
             v-if="!modelValue?.hasForeignSource"
             aria-label="Nach Entscheidung suchen"
             button-type="primary"
-            class="mr-16"
             label="Suchen"
             size="small"
             @click="search"
@@ -290,7 +289,6 @@ onBeforeUnmount(() => {
           <TextButton
             aria-label="Vorgehende Entscheidung speichern"
             button-type="tertiary"
-            class="mr-16"
             :disabled="previousDecision.isEmpty"
             label="Übernehmen"
             size="small"

--- a/frontend/src/components/PreviousDecisionInputGroup.vue
+++ b/frontend/src/components/PreviousDecisionInputGroup.vue
@@ -282,7 +282,7 @@ onBeforeUnmount(() => {
             v-if="!modelValue?.hasForeignSource"
             aria-label="Nach Entscheidung suchen"
             button-type="primary"
-            class="mr-24"
+            class="mr-16"
             label="Suchen"
             size="small"
             @click="search"
@@ -290,7 +290,7 @@ onBeforeUnmount(() => {
           <TextButton
             aria-label="Vorgehende Entscheidung speichern"
             button-type="tertiary"
-            class="mr-24"
+            class="mr-16"
             :disabled="previousDecision.isEmpty"
             label="Übernehmen"
             size="small"

--- a/frontend/src/components/input/TextButton.vue
+++ b/frontend/src/components/input/TextButton.vue
@@ -54,6 +54,26 @@ const renderIcon = () =>
 const renderLabel = () =>
   props.label ? h("span", { class: "ds-button-label" }, props.label) : undefined
 
+const getStyleForButtonWithIcon = () => {
+  const isButtonWithIcon = buttonClasses.value["ds-button-with-icon"]
+  const isButtonWithIconOnly = buttonClasses.value["ds-button-with-icon-only"]
+  const isIconLeft = props.iconPosition === "left"
+  const isIconRight = props.iconPosition === "right"
+  const isGhostButton = props.buttonType === "ghost"
+
+  const decreasePaddingLeft =
+    isButtonWithIcon && !isButtonWithIconOnly && isIconLeft && !isGhostButton
+  const decreasePaddingRight =
+    isButtonWithIcon && !isButtonWithIconOnly && isIconRight && !isGhostButton
+
+  if (decreasePaddingLeft) {
+    return { paddingLeft: "16px" }
+  } else if (decreasePaddingRight) {
+    return { paddingRight: "16px" }
+  }
+  return ""
+}
+
 const render = () => {
   const { disabled, href, download, target } = props
   let tag = "button"
@@ -68,6 +88,7 @@ const render = () => {
       "aria-label": props.ariaLabel,
       disabled: !href && disabled,
       href: sanitizedUrl.value,
+      style: getStyleForButtonWithIcon(),
       download,
       target,
     },
@@ -90,5 +111,9 @@ const render = () => {
 // eslint-disable vue-scoped-css/no-unused-selector
 .ds-button-large > .ds-button-icon {
   font-size: 2rem;
+}
+
+.ds-button.ds-button-ghost {
+  padding: 12px;
 }
 </style>

--- a/frontend/src/components/input/TextButton.vue
+++ b/frontend/src/components/input/TextButton.vue
@@ -44,9 +44,15 @@ const buttonClasses = computed(() => ({
   "ds-button-with-icon-only": props.icon && !props.label,
   "is-disabled": props.href && props.disabled,
   "pl-16":
-    props.icon && props.buttonType == "ghost" && props.iconPosition === "left",
+    props.icon &&
+    props.label &&
+    props.buttonType !== "ghost" &&
+    props.iconPosition === "left",
   "pr-16":
-    props.icon && props.buttonType == "ghost" && props.iconPosition === "right",
+    props.icon &&
+    props.label &&
+    props.buttonType !== "ghost" &&
+    props.iconPosition === "right",
 }))
 
 const isLink = computed(() => !!props.href)

--- a/frontend/src/components/input/TextButton.vue
+++ b/frontend/src/components/input/TextButton.vue
@@ -43,6 +43,10 @@ const buttonClasses = computed(() => ({
   "ds-button-with-icon": props.icon,
   "ds-button-with-icon-only": props.icon && !props.label,
   "is-disabled": props.href && props.disabled,
+  "pl-16":
+    props.icon && props.buttonType == "ghost" && props.iconPosition === "left",
+  "pr-16":
+    props.icon && props.buttonType == "ghost" && props.iconPosition === "right",
 }))
 
 const isLink = computed(() => !!props.href)
@@ -53,26 +57,6 @@ const renderIcon = () =>
 
 const renderLabel = () =>
   props.label ? h("span", { class: "ds-button-label" }, props.label) : undefined
-
-const getStyleForButtonWithIcon = () => {
-  const isButtonWithIcon = buttonClasses.value["ds-button-with-icon"]
-  const isButtonWithIconOnly = buttonClasses.value["ds-button-with-icon-only"]
-  const isIconLeft = props.iconPosition === "left"
-  const isIconRight = props.iconPosition === "right"
-  const isGhostButton = props.buttonType === "ghost"
-
-  const decreasePaddingLeft =
-    isButtonWithIcon && !isButtonWithIconOnly && isIconLeft && !isGhostButton
-  const decreasePaddingRight =
-    isButtonWithIcon && !isButtonWithIconOnly && isIconRight && !isGhostButton
-
-  if (decreasePaddingLeft) {
-    return { paddingLeft: "16px" }
-  } else if (decreasePaddingRight) {
-    return { paddingRight: "16px" }
-  }
-  return ""
-}
 
 const render = () => {
   const { disabled, href, download, target } = props
@@ -88,7 +72,6 @@ const render = () => {
       "aria-label": props.ariaLabel,
       disabled: !href && disabled,
       href: sanitizedUrl.value,
-      style: getStyleForButtonWithIcon(),
       download,
       target,
     },

--- a/frontend/src/kitchensink/components/DummyInputGroup.vue
+++ b/frontend/src/kitchensink/components/DummyInputGroup.vue
@@ -56,7 +56,7 @@ onBeforeUnmount(() => {
           <TextButton
             aria-label="Listeneintrag speichern"
             button-type="tertiary"
-            class="mr-24"
+            class="mr-16"
             :disabled="listEntry.isEmpty"
             label="Übernehmen"
             size="small"

--- a/frontend/src/kitchensink/components/DummyInputGroup.vue
+++ b/frontend/src/kitchensink/components/DummyInputGroup.vue
@@ -52,11 +52,10 @@ onBeforeUnmount(() => {
 
     <div class="flex w-full flex-row justify-between">
       <div>
-        <div>
+        <div class="flex gap-16">
           <TextButton
             aria-label="Listeneintrag speichern"
             button-type="tertiary"
-            class="mr-16"
             :disabled="listEntry.isEmpty"
             label="Übernehmen"
             size="small"

--- a/frontend/src/styles/global.scss
+++ b/frontend/src/styles/global.scss
@@ -2,13 +2,6 @@
 
 @tailwind base;
 
-@layer base {
-  ul,
-  ol {
-    padding: revert;
-    margin: revert;
-  }
-}
 @tailwind components;
 @tailwind utilities;
 
@@ -34,5 +27,11 @@
       font-family: BundesSansWeb, sans-serif;
       font-style: normal;
     }
+  }
+
+  ul,
+  ol {
+    padding: revert;
+    margin: revert;
   }
 }


### PR DESCRIPTION
RISDEV-3676

Requirements:
1. change the spacing between the buttons from 24 to 16px
2. All buttons (except ghost buttons) with icons (on left/right) -> change the icon's padding to 16 on the left/right
3. Ghost buttons with/without icon- > change side padding to 12px

Remark:
The second requirement was a bit tricky as the position of the icon is not available in a CSS class.

Before:
<img width="952" alt="image" src="https://github.com/digitalservicebund/ris-backend-service/assets/158598611/f4ba24a5-bac7-4f1f-8b2c-ff7ea7859963">
After:
<img width="952" alt="image" src="https://github.com/digitalservicebund/ris-backend-service/assets/158598611/d86a5ff4-c941-4737-a388-25a9ece9581b">
