### PR TITLE
Rework editable list

### DIFF
--- a/frontend/src/components/ActiveCitationInput.vue
+++ b/frontend/src/components/ActiveCitationInput.vue
@@ -24,7 +24,7 @@ const emit = defineEmits<{
   "update:modelValue": [value: ActiveCitation]
   addEntry: [void]
   cancelEdit: [void]
-  removeEntry: [void]
+  removeEntry: [value?: boolean]
 }>()
 
 const lastSearchInput = ref(new ActiveCitation())
@@ -299,7 +299,7 @@ onBeforeUnmount(() => {
         button-type="destructive"
         label="Eintrag löschen"
         size="small"
-        @click.stop="emit('removeEntry')"
+        @click.stop="emit('removeEntry', true)"
       />
     </div>
 

--- a/frontend/src/components/EditableList.vue
+++ b/frontend/src/components/EditableList.vue
@@ -26,6 +26,8 @@ const modelValueList = ref<T[]>([...props.modelValue]) as Ref<T[]>
 
 const editIndex = ref<number | undefined>()
 
+const shouldAddDefaultEntry = ref<boolean>(false)
+
 /**
  * Setting the edit index, renders the edit component of the given index, the summary component is not visible
  * @param {number} index - The index of the list item to be shown in edit mode
@@ -50,22 +52,25 @@ function addNewListEntry() {
     typeof defaultValue === "object" ? { ...defaultValue } : defaultValue,
   )
 
-  editIndex.value = modelValueList.value.length - 1
+  setEditIndex(modelValueList.value.length - 1)
 }
 
 /**
  * Removes the list item, with the given index, by propagating an updated list without the list item
  * at the given index to the parent component. The edit index is resetted, to show list in summary mode.
  * @param {number} index - The index of the list item to be removed
+ * @param {boolean} shouldResetEditIndex - Indicates if the editIndex should be reset to undefined
  */
-function removeEntry(index: number) {
+function removeEntry(index: number, shouldResetEditIndex?: boolean) {
   modelValueList.value.splice(index, 1)
 
   emit(
     "update:modelValue",
     [...props.modelValue].filter((_, i) => i !== index),
   )
-  editIndex.value = undefined
+  if (shouldResetEditIndex) {
+    setEditIndex()
+  }
 }
 
 /**
@@ -76,6 +81,7 @@ function removeEntry(index: number) {
 function updateModel() {
   setEditIndex()
   emit("update:modelValue", modelValueList.value)
+  shouldAddDefaultEntry.value = true
 }
 
 /**
@@ -88,6 +94,10 @@ watch(
     modelValueList.value = modelValueList.value.map((value, index) =>
       index == editIndex.value ? value : props.modelValue[index],
     )
+    if (shouldAddDefaultEntry.value) {
+      addNewListEntry()
+      shouldAddDefaultEntry.value = false
+    }
   },
   {
     immediate: true,
@@ -147,7 +157,7 @@ watch(
         :model-value-list="modelValueList"
         @add-entry="updateModel"
         @cancel-edit="cancelEdit"
-        @remove-entry="removeEntry(index)"
+        @remove-entry="(value?: boolean) => removeEntry(index, value)"
       />
     </div>
 

--- a/frontend/src/components/EnsuingDecisionInputGroup.vue
+++ b/frontend/src/components/EnsuingDecisionInputGroup.vue
@@ -24,7 +24,7 @@ const emit = defineEmits<{
   "update:modelValue": [value: EnsuingDecision]
   addEntry: [void]
   cancelEdit: [void]
-  removeEntry: [void]
+  removeEntry: [value?: boolean]
 }>()
 
 const lastSearchInput = ref(new EnsuingDecision())
@@ -299,7 +299,7 @@ onBeforeUnmount(() => {
         button-type="destructive"
         label="Eintrag löschen"
         size="small"
-        @click.stop="emit('removeEntry')"
+        @click.stop="emit('removeEntry', true)"
       />
     </div>
 

--- a/frontend/src/components/NormReferenceInput.vue
+++ b/frontend/src/components/NormReferenceInput.vue
@@ -19,7 +19,7 @@ const emit = defineEmits<{
   "update:modelValue": [value: NormReference]
   addEntry: [void]
   cancelEdit: [void]
-  removeEntry: [void]
+  removeEntry: [value?: boolean]
 }>()
 
 const validationStore =
@@ -79,7 +79,7 @@ async function addNormReference() {
 }
 
 async function removeNormReference() {
-  emit("removeEntry")
+  emit("removeEntry", true)
   singleNorms.value = []
 }
 

--- a/frontend/src/components/PreviousDecisionInputGroup.vue
+++ b/frontend/src/components/PreviousDecisionInputGroup.vue
@@ -25,7 +25,7 @@ const emit = defineEmits<{
   "update:modelValue": [value: PreviousDecision]
   addEntry: [void]
   cancelEdit: [void]
-  removeEntry: [void]
+  removeEntry: [value?: boolean]
 }>()
 
 const lastSearchInput = ref(new PreviousDecision())
@@ -310,7 +310,7 @@ onBeforeUnmount(() => {
         button-type="destructive"
         label="Eintrag löschen"
         size="small"
-        @click.stop="emit('removeEntry')"
+        @click.stop="emit('removeEntry', true)"
       />
     </div>
 

--- a/frontend/src/kitchensink/components/DummyInputGroup.vue
+++ b/frontend/src/kitchensink/components/DummyInputGroup.vue
@@ -13,7 +13,7 @@ const emit = defineEmits<{
   "update:modelValue": [value: DummyListItem]
   addEntry: [void]
   cancelEdit: [void]
-  removeEntry: [void]
+  removeEntry: [value?: boolean]
 }>()
 
 const lastSavedModelValue = ref(new DummyListItem({ ...props.modelValue }))
@@ -77,7 +77,7 @@ onBeforeUnmount(() => {
         button-type="destructive"
         label="Eintrag löschen"
         size="small"
-        @click.stop="emit('removeEntry')"
+        @click.stop="emit('removeEntry', true)"
       />
     </div>
   </div>

--- a/frontend/test/e2e/caselaw/categories/editableLists/editable-lists.spec.ts
+++ b/frontend/test/e2e/caselaw/categories/editableLists/editable-lists.spec.ts
@@ -91,7 +91,7 @@ test.describe("related documentation units", () => {
         await expect(container.getByText(fileNumber1)).toBeVisible()
 
         // edit entry
-        await container.getByLabel("Listen Eintrag").click()
+        await container.getByLabel("Listen Eintrag").first().click()
         await container
           .getByLabel("Aktenzeichen " + section, { exact: true })
           .fill(fileNumber2)
@@ -100,10 +100,10 @@ test.describe("related documentation units", () => {
         await expect(container.getByText(fileNumber1)).toBeHidden()
         await expect(container.getByText(fileNumber2)).toBeVisible()
 
-        await expect(container.getByLabel("Listen Eintrag")).toHaveCount(1)
+        // the second list item is a default list entry
+        await expect(container.getByLabel("Listen Eintrag")).toHaveCount(2)
 
         // add second entry
-        await container.getByLabel("Weitere Angabe").click()
         await waitForSaving(
           async () => {
             await container
@@ -115,13 +115,20 @@ test.describe("related documentation units", () => {
           { clickSaveButton: true },
         )
 
-        await expect(container.getByLabel("Listen Eintrag")).toHaveCount(2)
+        // the third list item is a default list entry
+        await expect(container.getByLabel("Listen Eintrag")).toHaveCount(3)
         await page.reload()
+        // the default list entry is not shown on reload page
+        await expect(container.getByLabel("Listen Eintrag")).toHaveCount(2)
+        await container.getByLabel("Weitere Angabe").isVisible()
+
         const listEntries = container.getByLabel("Listen Eintrag")
         await expect(listEntries).toHaveCount(2)
         await listEntries.first().click()
         await container.getByLabel("Eintrag löschen").click()
+        // the default list entry is not shown on delete item
         await expect(container.getByLabel("Listen Eintrag")).toHaveCount(1)
+        await container.getByLabel("Weitere Angabe").isVisible()
       })
     }
   })
@@ -172,6 +179,7 @@ test.describe("related documentation units", () => {
           await page
             .getByLabel(containerLabel, { exact: true })
             .getByLabel("Listen Eintrag")
+            .first()
             .click()
           if (container === activeCitationContainer) {
             await expect(
@@ -257,9 +265,9 @@ test.describe("related documentation units", () => {
 
           await container.getByLabel(`${containerLabel} speichern`).click()
 
-          await expect(container.getByLabel("Listen Eintrag")).toHaveCount(1)
+          await expect(container.getByLabel("Listen Eintrag")).toHaveCount(2)
 
-          await container.getByLabel("Listen Eintrag").click()
+          await container.getByLabel("Listen Eintrag").first().click()
           await expect(container.getByLabel("Abbrechen")).toBeVisible()
 
           await expect(
@@ -316,10 +324,9 @@ test.describe("related documentation units", () => {
             })
           }
           await container.getByLabel(`${containerLabel} speichern`).click()
-          await expect(container.getByLabel("Listen Eintrag")).toHaveCount(1)
+          await expect(container.getByLabel("Listen Eintrag")).toHaveCount(2)
 
           //list item 2
-          await container.getByLabel("Weitere Angabe").click()
           const fileNumber2 = generateString()
           if (container === activeCitationContainer) {
             await fillActiveCitationInputs(page, {
@@ -342,11 +349,9 @@ test.describe("related documentation units", () => {
             })
           }
           await container.getByLabel(`${containerLabel} speichern`).click()
-          await expect(container.getByLabel("Listen Eintrag")).toHaveCount(2)
+          await expect(container.getByLabel("Listen Eintrag")).toHaveCount(3)
 
           // leaving an empty list item, deletes it
-          await container.getByLabel("Weitere Angabe").click()
-          await expect(container.getByLabel("Listen Eintrag")).toHaveCount(3)
           await container.getByLabel("Listen Eintrag").nth(1).click()
           await expect(container.getByLabel("Listen Eintrag")).toHaveCount(2)
 
@@ -423,9 +428,9 @@ test.describe("related documentation units", () => {
 
           await container.getByLabel(`${containerLabel} speichern`).click()
 
-          await expect(container.getByLabel("Listen Eintrag")).toHaveCount(1)
+          await expect(container.getByLabel("Listen Eintrag")).toHaveCount(2)
 
-          await container.getByLabel("Listen Eintrag").click()
+          await container.getByLabel("Listen Eintrag").first().click()
 
           await expect(container.getByLabel("Abbrechen")).toBeVisible()
 
@@ -505,11 +510,9 @@ test.describe("related documentation units", () => {
 
           await container.getByLabel(`${containerLabel} speichern`).click()
 
-          await expect(container.getByLabel("Weitere Angabe")).toBeVisible()
+          await expect(container.getByLabel("Listen Eintrag")).toHaveCount(2)
 
-          await expect(container.getByLabel("Listen Eintrag")).toHaveCount(1)
-
-          await container.getByLabel("Listen Eintrag").click()
+          await container.getByLabel("Listen Eintrag").first().click()
 
           await expect(container.getByLabel("Weitere Angabe")).toBeHidden()
         },

--- a/frontend/test/e2e/caselaw/categories/editableLists/norms.spec.ts
+++ b/frontend/test/e2e/caselaw/categories/editableLists/norms.spec.ts
@@ -38,7 +38,7 @@ test.describe("norm", () => {
     await expect(container.getByText("PBefG")).toBeVisible()
 
     // edit entry
-    await container.getByLabel("Listen Eintrag").click()
+    await container.getByLabel("Listen Eintrag").first().click()
     await fillNormInputs(page, {
       normAbbreviation: "PBefGRVZustBehV NW",
     })
@@ -46,10 +46,10 @@ test.describe("norm", () => {
     await container.getByLabel("Norm speichern").click()
     await expect(container.getByText("PBefGRVZustBehV NW")).toBeVisible()
 
-    await expect(container.getByLabel("Listen Eintrag")).toHaveCount(1)
+    // the second list item is a default list entry
+    await expect(container.getByLabel("Listen Eintrag")).toHaveCount(2)
 
     // add second entry
-    await container.getByLabel("Weitere Angabe").click()
     await waitForSaving(
       async () => {
         await fillNormInputs(page, {
@@ -61,13 +61,21 @@ test.describe("norm", () => {
       { clickSaveButton: true },
     )
 
-    await expect(container.getByLabel("Listen Eintrag")).toHaveCount(2)
+    // the third list item is a default list entry
+    await expect(container.getByLabel("Listen Eintrag")).toHaveCount(3)
     await page.reload()
+    // the default list entry is not shown on reload page
+    await expect(container.getByLabel("Listen Eintrag")).toHaveCount(2)
+    await container.getByLabel("Weitere Angabe").isVisible()
+
     const listEntries = container.getByLabel("Listen Eintrag")
     await expect(listEntries).toHaveCount(2)
+
     await listEntries.first().click()
     await container.getByLabel("Eintrag löschen").click()
+    // the default list entry is not shown on delete item
     await expect(container.getByLabel("Listen Eintrag")).toHaveCount(1)
+    await container.getByLabel("Weitere Angabe").isVisible()
   })
 
   test("single norm validation", async ({ page, documentNumber }) => {

--- a/frontend/test/e2e/caselaw/categories/editableLists/relatedDocumentations/ensuing-decisions.spec.ts
+++ b/frontend/test/e2e/caselaw/categories/editableLists/relatedDocumentations/ensuing-decisions.spec.ts
@@ -56,9 +56,8 @@ test.describe("ensuing decisions", () => {
 
     await expect(
       ensuingDecisionContainer.getByLabel("Listen Eintrag"),
-    ).toHaveCount(1)
+    ).toHaveCount(2)
 
-    await page.getByLabel("Weitere Angabe").click()
     await fillEnsuingDecisionInputs(page, {
       court: prefilledDocumentUnit.coreData.court?.label,
       fileNumber: prefilledDocumentUnit.coreData.fileNumbers?.[0],
@@ -87,7 +86,7 @@ test.describe("ensuing decisions", () => {
 
     await expect(
       ensuingDecisionContainer.getByLabel("Listen Eintrag"),
-    ).toHaveCount(2)
+    ).toHaveCount(3)
   })
 
   test("only note of linked ensuing decision is editable", async ({
@@ -129,6 +128,7 @@ test.describe("ensuing decisions", () => {
     await page
       .getByLabel("Nachgehende Entscheidung", { exact: true })
       .getByLabel("Listen Eintrag")
+      .first()
       .click()
     await expect(
       page.getByLabel("Gericht Nachgehende Entscheidung"),

--- a/frontend/test/e2e/caselaw/categories/editableLists/relatedDocumentations/previous-decisions.spec.ts
+++ b/frontend/test/e2e/caselaw/categories/editableLists/relatedDocumentations/previous-decisions.spec.ts
@@ -68,7 +68,7 @@ test.describe("previous decisions", () => {
     await page
       .locator("[aria-label='Aktenzeichen Vorgehende Entscheidung']")
       .fill(fileNumber)
-    // Knödel
+
     await page
       .locator(
         "[aria-label='Abweichendes Aktenzeichen Vorgehende Entscheidung anzeigen']",
@@ -99,6 +99,7 @@ test.describe("previous decisions", () => {
     await page
       .getByLabel("Vorgehende Entscheidung", { exact: true })
       .getByLabel("Listen Eintrag")
+      .first()
       .click()
     await page
       .locator(
@@ -128,6 +129,7 @@ test.describe("previous decisions", () => {
     await page
       .getByLabel("Vorgehende Entscheidung", { exact: true })
       .getByLabel("Listen Eintrag")
+      .first()
       .click()
     // if 'Abweichendes Aktenzeichen' input filled, the nested input is expanded
     await page
@@ -220,7 +222,7 @@ test.describe("previous decisions", () => {
 
     // Clean up:
     // We need to unlink the document units in order to be allowed to delete them in the fixtures
-    await previousDecisionContainer.getByLabel("Listen Eintrag").click()
+    await previousDecisionContainer.getByLabel("Listen Eintrag").first().click()
     await previousDecisionContainer.getByLabel("Eintrag löschen").click()
 
     await page.getByText("Speichern").click()

--- a/frontend/test/e2e/caselaw/categories/editableLists/relatedDocumentations/small-search.spec.ts
+++ b/frontend/test/e2e/caselaw/categories/editableLists/relatedDocumentations/small-search.spec.ts
@@ -65,13 +65,11 @@ test("search for documentunits and link decision", async ({
           summary = `nachgehend, ` + summary
         }
 
-        const listItem = container.getByLabel("Listen Eintrag").last()
+        const listItem = container.getByLabel("Listen Eintrag").first()
         await expect(listItem).toBeVisible()
         await expect(listItem).toContainText(summary, { useInnerText: true })
 
         // search for same parameters gives same result, indication that decision is already added
-        await container.getByLabel("Weitere Angabe").click()
-
         if (container === activeCitationContainer) {
           await fillActiveCitationInputs(page, inputs)
         }
@@ -282,13 +280,11 @@ test("clicking on link of referenced documentation unit added by search opens ne
         const newTab = await newTabPromise
         await newTab.waitForLoadState()
 
-        await expect(newTab.url()).toContain(
+        expect(newTab.url()).toContain(
           `${prefilledDocumentUnit.documentNumber}`,
         )
 
-        await expect(
-          container.getByLabel("Nach Entscheidung suchen"),
-        ).toBeHidden()
+        await newTab.close()
 
         // Clean up: We need to unlink the document units in order to be allowed to delete them in the fixtures
         await container.getByText("AG Aachen, 31.12.2019").first().click()


### PR DESCRIPTION
After adding a new list entry we display a new (default and empty) entry.

[RISDEV-3547](https://digitalservicebund.atlassian.net/browse/RISDEV-3547)

[RISDEV-3547]: https://digitalservicebund.atlassian.net/browse/RISDEV-3547?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ