### PR TITLE
Enable repeated search in DocumentUnitSearchEntryForm

### DIFF
--- a/frontend/src/components/DocumentUnitSearch.vue
+++ b/frontend/src/components/DocumentUnitSearch.vue
@@ -28,7 +28,7 @@ const isLoading = ref(false)
 const searchQuery = ref<Query<DocumentUnitSearchParameter>>()
 const pageNumber = ref<number>(0)
 
-const emptyStatus = computed(() => {
+const emptyStateLabel = computed(() => {
   if (!documentUnitListEntries.value) {
     return "Starten Sie die Suche oder erstellen Sie eine neue Dokumentationseinheit."
   } else if (documentUnitListEntries.value.length === 0) {
@@ -241,7 +241,7 @@ const showDefaultLink = computed(() => {
       <DocumentUnitList
         class="grow"
         :document-unit-list-entries="documentUnitListEntries"
-        :empty-state="emptyStatus"
+        :empty-state="emptyStateLabel"
         is-deletable
         :is-loading="isLoading"
         :search-response-error="searchResponseError"

--- a/frontend/src/components/DocumentUnitSearchEntryForm.vue
+++ b/frontend/src/components/DocumentUnitSearchEntryForm.vue
@@ -140,6 +140,16 @@ function handleLocalInputError(error: ValidationError | undefined, id: string) {
   validateSearchInput()
 }
 
+/**
+ * Computed property that determines whether the current search query is identical to the previous search query.
+ * @returns {ComputedRef<boolean>} - Returns `true` if the queries are identical, otherwise `false`.
+ */
+const isIdenticalSearch = (): boolean => {
+  const previousQuery = getQueryFromRoute()
+  const newQuery = query.value
+  return JSON.stringify(previousQuery) === JSON.stringify(newQuery)
+}
+
 function handleSearchButtonClicked() {
   validateSearchInput()
 
@@ -147,7 +157,9 @@ function handleSearchButtonClicked() {
     return
   }
 
-  handleSearch()
+  if (isIdenticalSearch()) {
+    handleSearch()
+  }
   pushQueryToRoute(query.value)
 }
 

--- a/frontend/test/components/documentUnitSearchEntryForm.spec.ts
+++ b/frontend/test/components/documentUnitSearchEntryForm.spec.ts
@@ -1,5 +1,6 @@
 import { userEvent } from "@testing-library/user-event"
 import { render, screen } from "@testing-library/vue"
+import { expect } from "vitest"
 import { createRouter, createWebHistory } from "vue-router"
 import DocumentUnitSearchEntryForm from "@/components/DocumentUnitSearchEntryForm.vue"
 
@@ -65,6 +66,25 @@ describe("Documentunit search form", () => {
     )
 
     expect(emitted().search).toBeTruthy()
+  })
+
+  test("click on 'Ergebnisse anzeigen' with the same search entry, emits search event again", async () => {
+    const { emitted, user } = await renderComponent()
+
+    await user.type(
+      screen.getByLabelText("Entscheidungsdatum Suche"),
+      "23.03.2003",
+    )
+    await user.click(
+      screen.getByLabelText("Nach Dokumentationseinheiten suchen"),
+    )
+    expect(emitted().search.length).toBe(2)
+
+    await user.click(
+      screen.getByLabelText("Nach Dokumentationseinheiten suchen"),
+    )
+
+    expect(emitted().search.length).toBe(3)
   })
 
   test("click on 'Nur meine Dokstelle' renders 'Nur fehlerhafte Dokumentationseinheiten' checkbox", async () => {

--- a/frontend/test/components/documentUnitSearchEntryForm.spec.ts
+++ b/frontend/test/components/documentUnitSearchEntryForm.spec.ts
@@ -78,13 +78,13 @@ describe("Documentunit search form", () => {
     await user.click(
       screen.getByLabelText("Nach Dokumentationseinheiten suchen"),
     )
-    expect(emitted().search.length).toBe(2)
+    expect(emitted().search.length).toBe(1)
 
     await user.click(
       screen.getByLabelText("Nach Dokumentationseinheiten suchen"),
     )
 
-    expect(emitted().search.length).toBe(3)
+    expect(emitted().search.length).toBe(2)
   })
 
   test("click on 'Nur meine Dokstelle' renders 'Nur fehlerhafte Dokumentationseinheiten' checkbox", async () => {

--- a/frontend/test/e2e/caselaw/documentunit-search.spec.ts
+++ b/frontend/test/e2e/caselaw/documentunit-search.spec.ts
@@ -351,6 +351,7 @@ test.describe("search", () => {
     ).toBeVisible()
 
     await page.getByLabel("Entscheidungsdatum Suche", { exact: true }).clear()
+    await page.getByLabel("Entscheidungsdatum Suche", { exact: true }).blur()
     await expect(page.getByText("Startdatum fehlt")).toBeVisible()
     await expect(
       page.getByText("Enddatum darf nich vor Startdatum liegen"),
@@ -360,6 +361,9 @@ test.describe("search", () => {
     await page
       .getByLabel("Entscheidungsdatum Suche Ende", { exact: true })
       .clear()
+    await page
+      .getByLabel("Entscheidungsdatum Suche Ende", { exact: true })
+      .blur()
     await expect(page.getByText("Startdatum fehlt")).toBeHidden()
   })
 


### PR DESCRIPTION
For the technical reviewer:

I need some hint for the test which works when I run all tests in documentUnitSearchEntryForm.spec.ts at once but which fails when started individually.

RISDEV-4003