### PR TITLE
Unify permissions

### DIFF
--- a/backend/src/main/java/de/bund/digitalservice/ris/caselaw/adapter/DocumentationUnitController.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/caselaw/adapter/DocumentationUnitController.java
@@ -110,7 +110,7 @@ public class DocumentationUnitController {
   }
 
   @PutMapping(value = "/{documentNumber}/takeover", produces = MediaType.APPLICATION_JSON_VALUE)
-  @PreAuthorize("@userHasSameDocOfficeAsDocumentByDocumentNumber.apply(#documentNumber)")
+  @PreAuthorize("@userHasSameDocOfficeAsDocument.apply(#documentNumber)")
   public ResponseEntity<DocumentationUnitListItem> takeOverDocumentationUnit(
       @AuthenticationPrincipal OidcUser oidcUser, @PathVariable String documentNumber) {
     try {
@@ -219,7 +219,11 @@ public class DocumentationUnitController {
       var documentationUnit = service.getByDocumentNumber(documentNumber);
       return ResponseEntity.ok(
           documentationUnit.toBuilder()
-              .isEditable(oAuthService.userHasWriteAccess(oidcUser, documentationUnit))
+              .isEditable(
+                  oAuthService.userHasWriteAccess(
+                      oidcUser,
+                      documentationUnit.coreData().creatingDocOffice(),
+                      documentationUnit.coreData().documentationOffice()))
               .build());
     } catch (DocumentationUnitNotExistsException e) {
       log.error("Documentation unit '{}' doesn't exist", documentNumber);

--- a/backend/src/main/java/de/bund/digitalservice/ris/caselaw/adapter/DocumentationUnitController.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/caselaw/adapter/DocumentationUnitController.java
@@ -228,8 +228,7 @@ public class DocumentationUnitController {
   }
 
   @DeleteMapping(value = "/{uuid}")
-  @PreAuthorize(
-      "@userIsInternal.apply(#oidcUser) and (@userHasWriteAccess.apply(#uuid) || @userHasDeletePermissions.apply(#uuid))")
+  @PreAuthorize("@userIsInternal.apply(#oidcUser) and @userHasWriteAccess.apply(#uuid)")
   public ResponseEntity<String> deleteByUuid(
       @AuthenticationPrincipal OidcUser oidcUser, @PathVariable UUID uuid) {
 

--- a/backend/src/main/java/de/bund/digitalservice/ris/caselaw/adapter/OAuthService.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/caselaw/adapter/OAuthService.java
@@ -210,19 +210,6 @@ public class OAuthService implements AuthService {
     };
   }
 
-  @Bean
-  public Function<UUID, Boolean> userHasDeletePermissions() {
-    return uuid -> {
-      try {
-        return Optional.ofNullable(documentationUnitService.getByUuid(uuid))
-            .map(this::userHasDeletePermissions)
-            .orElse(false);
-      } catch (DocumentationUnitNotExistsException e) {
-        return false;
-      }
-    };
-  }
-
   public boolean userHasWriteAccess(OidcUser oidcUser, DocumentationUnit documentationUnit) {
     DocumentationOffice userDocumentationOffice = userService.getDocumentationOffice(oidcUser);
     return documentationUnit.status() != null && docUnitIsPending(documentationUnit.status())
@@ -244,15 +231,6 @@ public class OAuthService implements AuthService {
     return status != null && docUnitIsPending(status)
         ? userHasSameDocOfficeAsDocumentCreator(userDocumentationOffice, creatingDocOffice, status)
         : userHasSameDocOfficeAsDocument(userDocumentationOffice, documentationOffice);
-  }
-
-  @Override
-  public boolean userCanDelete(
-      OidcUser oidcUser, DocumentationOffice documentationOffice, Status status) {
-    DocumentationOffice userDocumentationOffice = userService.getDocumentationOffice(oidcUser);
-    return status != null
-        && docUnitIsPending(status)
-        && userHasSameDocOfficeAsDocument(userDocumentationOffice, documentationOffice);
   }
 
   @Bean
@@ -341,12 +319,6 @@ public class OAuthService implements AuthService {
     return documentationUnit.status() != null && docUnitIsPending(documentationUnit.status())
         ? userHasSameDocOfficeAsDocumentCreator(documentationUnit)
         : userHasSameDocOfficeAsDocument(documentationUnit);
-  }
-
-  private boolean userHasDeletePermissions(DocumentationUnit documentationUnit) {
-    return documentationUnit.status() != null
-        && docUnitIsPending(documentationUnit.status())
-        && userHasSameDocOfficeAsDocument(documentationUnit);
   }
 
   private boolean userHasReadAccess(DocumentationUnit documentationUnit) {

--- a/backend/src/main/java/de/bund/digitalservice/ris/caselaw/domain/AuthService.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/caselaw/domain/AuthService.java
@@ -5,14 +5,12 @@ import java.util.function.Function;
 import org.springframework.security.oauth2.core.oidc.user.OidcUser;
 
 public interface AuthService {
+  Function<OidcUser, Boolean> userIsInternal();
+
+  Function<UUID, Boolean> isAssignedViaProcedure();
 
   boolean userHasWriteAccess(
       OidcUser oidcUser,
       DocumentationOffice creatingDocOffice,
-      DocumentationOffice documentationOffice,
-      Status status);
-
-  Function<OidcUser, Boolean> userIsInternal();
-
-  Function<UUID, Boolean> isAssignedViaProcedure();
+      DocumentationOffice documentationOffice);
 }

--- a/backend/src/main/java/de/bund/digitalservice/ris/caselaw/domain/AuthService.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/caselaw/domain/AuthService.java
@@ -6,8 +6,6 @@ import org.springframework.security.oauth2.core.oidc.user.OidcUser;
 
 public interface AuthService {
 
-  boolean userCanDelete(OidcUser oidcUser, DocumentationOffice documentationOffice, Status status);
-
   boolean userHasWriteAccess(
       OidcUser oidcUser,
       DocumentationOffice creatingDocOffice,

--- a/backend/src/main/java/de/bund/digitalservice/ris/caselaw/domain/DocumentationUnitService.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/caselaw/domain/DocumentationUnitService.java
@@ -189,10 +189,7 @@ public class DocumentationUnitService {
 
     boolean hasWriteAccess =
         authService.userHasWriteAccess(
-            oidcUser,
-            listItem.creatingDocumentationOffice(),
-            listItem.documentationOffice(),
-            listItem.status());
+            oidcUser, listItem.creatingDocumentationOffice(), listItem.documentationOffice());
     boolean isInternalUser = authService.userIsInternal().apply(oidcUser);
 
     return listItem.toBuilder()

--- a/backend/src/main/java/de/bund/digitalservice/ris/caselaw/domain/DocumentationUnitService.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/caselaw/domain/DocumentationUnitService.java
@@ -193,12 +193,10 @@ public class DocumentationUnitService {
             listItem.creatingDocumentationOffice(),
             listItem.documentationOffice(),
             listItem.status());
-    boolean permissionToDelete =
-        authService.userCanDelete(oidcUser, listItem.documentationOffice(), listItem.status());
     boolean isInternalUser = authService.userIsInternal().apply(oidcUser);
 
     return listItem.toBuilder()
-        .isDeletable((hasWriteAccess || permissionToDelete) && isInternalUser)
+        .isDeletable(hasWriteAccess && isInternalUser)
         .isEditable(
             (hasWriteAccess
                 && (isInternalUser || authService.isAssignedViaProcedure().apply(listItem.uuid()))))


### PR DESCRIPTION
This commit streamlines permission handling in AuthService by making it less restrictive, especially for pending documentation units. Both the creating and owning documentation offices can now edit and delete documents. While the UI ensures the owning office cannot enter edit mode before a takeover, this change reduces code complexity (e.g. the status and docUnitIsPending checks are not needed anymore.)

Additionally, hasWriteAccess permissions have been unified. Beans like userHasSameDocOfficeAsDocument were removed since they are now covered by hasWriteAccess.

This should improve code readability and may also enhance performance by reducing redundant checks.