### PR TITLE
Improve visibility of local env by using rainbow

### DIFF
--- a/frontend/src/assets/favicon-local.svg
+++ b/frontend/src/assets/favicon-local.svg
@@ -1,0 +1,17 @@
+<svg width="256" height="256" viewBox="0 0 256 256" xmlns="http://www.w3.org/2000/svg">
+    <g clip-path="url(#clip0_14311_27791)">
+        <rect width="256" height="256" fill="white"/>
+        <rect y="0" width="256" height="36.57" fill="#FF0000"/>
+        <rect y="36.57" width="256" height="36.57" fill="#FF7F00"/>
+        <rect y="73.14" width="256" height="36.57" fill="#FFFF00"/>
+        <rect y="109.71" width="256" height="36.57" fill="#00FF00"/>
+        <rect y="146.28" width="256" height="36.57" fill="#0000FF"/>
+        <rect y="182.85" width="256" height="36.57" fill="#4B0082"/>
+        <rect y="219.42" width="256" height="36.57" fill="#9400D3"/>
+    </g>
+    <defs>
+        <clipPath id="clip0_14311_27791">
+            <rect width="256" height="256" fill="white"/>
+        </clipPath>
+    </defs>
+</svg>

--- a/frontend/src/utils/getFavicon.ts
+++ b/frontend/src/utils/getFavicon.ts
@@ -4,10 +4,11 @@ import stagingFavicon from "@/assets/favicon-staging.svg"
 import uatFavicon from "@/assets/favicon-uat.svg"
 
 export const getFavicon = (env?: string) => {
-  const isLocal = import.meta.env.MODE === "development"
-  if (isLocal) {
-    return localFavicon
-  } else if (env == "staging") {
+  if (env == "staging") {
+    const isLocal = import.meta?.env?.MODE === "development"
+    if (isLocal) {
+      return localFavicon
+    }
     return stagingFavicon
   } else if (env == "uat") {
     return uatFavicon

--- a/frontend/src/utils/getFavicon.ts
+++ b/frontend/src/utils/getFavicon.ts
@@ -1,9 +1,13 @@
+import localFavicon from "@/assets/favicon-local.svg"
 import productionFavicon from "@/assets/favicon-production.svg"
 import stagingFavicon from "@/assets/favicon-staging.svg"
 import uatFavicon from "@/assets/favicon-uat.svg"
 
 export const getFavicon = (env?: string) => {
-  if (env == "staging") {
+  const isLocal = import.meta.env.MODE === "development"
+  if (isLocal) {
+    return localFavicon
+  } else if (env == "staging") {
     return stagingFavicon
   } else if (env == "uat") {
     return uatFavicon

--- a/frontend/src/utils/getFavicon.ts
+++ b/frontend/src/utils/getFavicon.ts
@@ -5,7 +5,7 @@ import uatFavicon from "@/assets/favicon-uat.svg"
 
 export const getFavicon = (env?: string) => {
   if (env == "staging") {
-    const isLocal = import.meta?.env?.MODE === "development"
+    const isLocal = import.meta.env?.MODE === "development"
     if (isLocal) {
       return localFavicon
     }

--- a/frontend/test/utils/getFavicon.spec.ts
+++ b/frontend/test/utils/getFavicon.spec.ts
@@ -4,9 +4,11 @@ describe("getFavicon", () => {
   it.each(["staging", "uat", "production"])(
     "returns correct favicon for %s",
     (environment) => {
+      vi.stubEnv("MODE", "production")
       const favicon = getFavicon(environment)
 
       expect(favicon).toBe(`/src/assets/favicon-${environment}.svg`)
+      vi.unstubAllEnvs()
     },
   )
 
@@ -14,5 +16,14 @@ describe("getFavicon", () => {
     const favicon = getFavicon("foo")
 
     expect(favicon).toBe(`/src/assets/favicon-production.svg`)
+  })
+
+  it("returns correct favicon for local", () => {
+    vi.stubEnv("MODE", "development")
+
+    const favicon = getFavicon("staging")
+
+    expect(favicon).toBe(`/src/assets/favicon-local.svg`)
+    vi.unstubAllEnvs()
   })
 })


### PR DESCRIPTION
As the favicon looks exactly the same in local and staging environment it happens that you mix up the browser tabs. With this change this will not happen anymore.

Left after, right before...
<img width="605" alt="image" src="https://github.com/user-attachments/assets/54c88b42-6c8b-4ec0-9f97-e28b9ffe5b79">
