### PR TITLE
Strengthening recycling service conditions

### DIFF
--- a/backend/src/main/java/de/bund/digitalservice/ris/caselaw/adapter/DatabaseDocumentNumberRecyclingService.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/caselaw/adapter/DatabaseDocumentNumberRecyclingService.java
@@ -173,7 +173,6 @@ public class DatabaseDocumentNumberRecyclingService implements DocumentNumberRec
    * @throws DocumentNumberRecyclingException will through error if published / handed over or
    *     status history not empty.
    */
-  @Override
   public void assertStatusHasNeverBeenPublished(DocumentationUnitDTO documentationUnitDTO)
       throws DocumentNumberRecyclingException {
     PublicationStatus status = documentationUnitDTO.getStatus().getPublicationStatus();

--- a/backend/src/main/java/de/bund/digitalservice/ris/caselaw/adapter/DatabaseDocumentNumberRecyclingService.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/caselaw/adapter/DatabaseDocumentNumberRecyclingService.java
@@ -80,7 +80,7 @@ public class DatabaseDocumentNumberRecyclingService implements DocumentNumberRec
       repository.save(deleted);
 
     } catch (Exception e) {
-      log.warn("Won´t reuse the document number", e);
+      log.info("Won´t reuse the document number", e);
       throw e;
     }
   }

--- a/backend/src/main/java/de/bund/digitalservice/ris/caselaw/adapter/DatabaseDocumentNumberRecyclingService.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/caselaw/adapter/DatabaseDocumentNumberRecyclingService.java
@@ -5,68 +5,70 @@ import static de.bund.digitalservice.ris.caselaw.domain.DateUtil.getYear;
 import de.bund.digitalservice.ris.caselaw.adapter.database.jpa.DatabaseDeletedDocumentationIdsRepository;
 import de.bund.digitalservice.ris.caselaw.adapter.database.jpa.DatabaseDocumentationUnitRepository;
 import de.bund.digitalservice.ris.caselaw.adapter.database.jpa.DeletedDocumentationUnitDTO;
+import de.bund.digitalservice.ris.caselaw.adapter.database.jpa.DocumentationUnitDTO;
 import de.bund.digitalservice.ris.caselaw.domain.DocumentNumberRecyclingService;
+import de.bund.digitalservice.ris.caselaw.domain.HandoverEntityType;
+import de.bund.digitalservice.ris.caselaw.domain.HandoverService;
 import de.bund.digitalservice.ris.caselaw.domain.PublicationStatus;
 import de.bund.digitalservice.ris.caselaw.domain.exception.DocumentNumberPatternException;
+import de.bund.digitalservice.ris.caselaw.domain.exception.DocumentNumberRecyclingException;
 import de.bund.digitalservice.ris.caselaw.domain.exception.DocumentationUnitNotExistsException;
 import java.time.Year;
-import java.util.Optional;
 import java.util.UUID;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
-/** Service to keep track off deleted unpublished documentation units that can be recycled */
+/** Service to handle deleted unpublished documentation units that can be recycled */
 @Service
 @Slf4j
 public class DatabaseDocumentNumberRecyclingService implements DocumentNumberRecyclingService {
 
   private final DatabaseDeletedDocumentationIdsRepository repository;
+  private final DatabaseDocumentationUnitRepository documentationUnitRepository;
+
   private final DocumentNumberPatternConfig documentNumberPatternConfig;
 
-  private final DatabaseDocumentationUnitRepository documentationUnitRepository;
+  private final HandoverService handoverService;
 
   public DatabaseDocumentNumberRecyclingService(
       DatabaseDeletedDocumentationIdsRepository repository,
       DocumentNumberPatternConfig documentNumberPatternConfig,
+      HandoverService handoverService,
       DatabaseDocumentationUnitRepository documentationUnitRepository) {
     this.repository = repository;
     this.documentNumberPatternConfig = documentNumberPatternConfig;
+    this.handoverService = handoverService;
     this.documentationUnitRepository = documentationUnitRepository;
   }
 
   /**
    * A method to track deleted unpublished document for reuse
    *
-   * @param documentationUnitId
-   * @param documentationUnitNumber
-   * @param documentationOfficeAbbreviation
-   * @return
+   * @param documentationUnitId uuid of the documentation unit
+   * @param documentationUnitNumber following by the validation pattern of juris
+   * @param documentationOfficeAbbreviation office abbreviation
    */
   @Override
-  public Optional<String> addForRecycling(
+  public void addForRecycling(
       UUID documentationUnitId,
       String documentationUnitNumber,
-      String documentationOfficeAbbreviation) {
+      String documentationOfficeAbbreviation)
+      throws DocumentNumberPatternException,
+          DocumentationUnitNotExistsException,
+          DocumentNumberRecyclingException {
 
     try {
 
-      if (!documentNumberPatternConfig.hasValidPattern(
-          documentationOfficeAbbreviation, documentationUnitNumber)) {
-        throw new DocumentNumberPatternException("Pattern is invalid");
-      }
+      assertPatternIsValid(documentationOfficeAbbreviation, documentationUnitNumber);
 
       var docUnit =
           documentationUnitRepository
               .findById(documentationUnitId)
               .orElseThrow(() -> new DocumentationUnitNotExistsException(documentationUnitId));
 
-      PublicationStatus status = docUnit.getStatus().getPublicationStatus();
-      if (docUnit.getStatusHistory().size() != 1
-          || !(status.equals(PublicationStatus.UNPUBLISHED)
-              || status.equals(PublicationStatus.EXTERNAL_HANDOVER_PENDING))) {
-        throw new DocumentNumberPatternException(
-            "Status is changed or neither unpublished nor pending");
-      }
+      assertDocumentationUnitHasNeverBeenHandedOverOrMigrated(documentationUnitId);
+
+      assertStatusHasNeverBeenPublished(docUnit);
 
       var deleted =
           DeletedDocumentationUnitDTO.builder()
@@ -75,45 +77,111 @@ public class DatabaseDocumentNumberRecyclingService implements DocumentNumberRec
               .abbreviation(documentationOfficeAbbreviation)
               .build();
 
-      return Optional.of(repository.save(deleted).getDocumentNumber());
+      repository.save(deleted);
 
     } catch (Exception e) {
       log.warn("Won´t reuse the document number", e);
-      return Optional.empty();
+      throw e;
     }
   }
 
   /**
-   * Returns a reusable document number
+   * Returns a reusable document number from the saved entries. It will remove it from the list in
+   * case it does not meet the function condition.
    *
-   * @param documentationOfficeAbbreviation
-   * @param year
-   * @return
+   * @param documentationOfficeAbbreviation the court abbreviation as it is saved in the deleted
+   *     document numbers table.
+   * @param year the year to search for, default is the current year.
+   * @return a document number to reuse.
    */
-  public Optional<String> findDeletedDocumentNumber(
-      String documentationOfficeAbbreviation, Year year) {
+  @Override
+  public String recycleFromDeletedDocumentationUnit(
+      String documentationOfficeAbbreviation, Year year)
+      throws DocumentNumberPatternException, DocumentNumberRecyclingException {
 
     var optionalDeletedDocumentationUnitDTO =
         repository.findFirstByAbbreviationAndYear(documentationOfficeAbbreviation, year);
 
     try {
       if (optionalDeletedDocumentationUnitDTO.isEmpty()) {
-        return Optional.empty();
+        throw new DocumentNumberRecyclingException("No documentation number to reuse");
       }
 
       var deletedDocumentationUnitDTO = optionalDeletedDocumentationUnitDTO.get();
 
-      if (!documentNumberPatternConfig.hasValidPattern(
-          documentationOfficeAbbreviation, deletedDocumentationUnitDTO.getDocumentNumber())) {
-        throw new DocumentNumberPatternException("Pattern is invalid");
+      if (documentationUnitRepository
+          .findByDocumentNumber(deletedDocumentationUnitDTO.getDocumentNumber())
+          .isPresent()) {
+        throw new DocumentNumberRecyclingException(
+            "Saved documentation number is currently in use");
       }
-      return Optional.of(deletedDocumentationUnitDTO.getDocumentNumber());
+
+      assertPatternIsValid(
+          documentationOfficeAbbreviation, deletedDocumentationUnitDTO.getDocumentNumber());
+
+      return deletedDocumentationUnitDTO.getDocumentNumber();
 
     } catch (Exception e) {
       optionalDeletedDocumentationUnitDTO.ifPresent(
           deletedDocumentationUnitDTO ->
               repository.deleteById(deletedDocumentationUnitDTO.getDocumentNumber()));
-      return Optional.empty();
+      throw e;
+    }
+  }
+
+  /**
+   * Documentation unit number can be only reused if it has never been handed over or migrated from
+   * jdv.
+   *
+   * @param documentationUnitId Uuid of the reused documentation unit
+   * @throws DocumentNumberRecyclingException will throw error if has been ever used.
+   */
+  @Override
+  public void assertDocumentationUnitHasNeverBeenHandedOverOrMigrated(UUID documentationUnitId)
+      throws DocumentNumberRecyclingException {
+    if (!handoverService
+        .getEventLog(documentationUnitId, HandoverEntityType.DOCUMENTATION_UNIT)
+        .isEmpty()) {
+      throw new DocumentNumberRecyclingException(
+          "This Documentation unit has already been handed over or migrated and therefore cannot be reused");
+    }
+  }
+
+  /**
+   * Validates that the documentationUnitNumber to be recycled meets the latest condition set in
+   * documentNumberPatternConfig, that are driven from the yml format
+   *
+   * @param documentationOfficeAbbreviation office abbreviation
+   * @param documentationUnitNumber documentation unit number
+   * @throws DocumentNumberPatternException in case a pattern does not correspond to latest pattern.
+   */
+  @Override
+  public void assertPatternIsValid(
+      String documentationOfficeAbbreviation, String documentationUnitNumber)
+      throws DocumentNumberPatternException {
+    if (!documentNumberPatternConfig.hasValidPattern(
+        documentationOfficeAbbreviation, documentationUnitNumber)) {
+      throw new DocumentNumberPatternException("Pattern is invalid");
+    }
+  }
+
+  /**
+   * Validates that a documentation unit number has never been published or handed over by its
+   * status
+   *
+   * @param documentationUnitDTO dto object
+   * @throws DocumentNumberRecyclingException will through error if published / handed over or
+   *     status history not empty.
+   */
+  @Override
+  public void assertStatusHasNeverBeenPublished(DocumentationUnitDTO documentationUnitDTO)
+      throws DocumentNumberRecyclingException {
+    PublicationStatus status = documentationUnitDTO.getStatus().getPublicationStatus();
+    if (documentationUnitDTO.getStatusHistory().size() != 1
+        || !(status.equals(PublicationStatus.UNPUBLISHED)
+            || status.equals(PublicationStatus.EXTERNAL_HANDOVER_PENDING))) {
+      throw new DocumentNumberRecyclingException(
+          "Status has been changed once or neither unpublished nor handover pending");
     }
   }
 

--- a/backend/src/main/java/de/bund/digitalservice/ris/caselaw/domain/DocumentNumberRecyclingService.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/caselaw/domain/DocumentNumberRecyclingService.java
@@ -1,15 +1,31 @@
 package de.bund.digitalservice.ris.caselaw.domain;
 
+import de.bund.digitalservice.ris.caselaw.adapter.database.jpa.DocumentationUnitDTO;
+import de.bund.digitalservice.ris.caselaw.domain.exception.DocumentNumberPatternException;
+import de.bund.digitalservice.ris.caselaw.domain.exception.DocumentNumberRecyclingException;
+import de.bund.digitalservice.ris.caselaw.domain.exception.DocumentationUnitNotExistsException;
 import java.time.Year;
-import java.util.Optional;
 import java.util.UUID;
 
 public interface DocumentNumberRecyclingService {
 
-  Optional<String> addForRecycling(
-      UUID documentationOfficeId, String documentNumber, String documentationOfficeAbbreviation);
+  void addForRecycling(
+      UUID documentationOfficeId, String documentNumber, String documentationOfficeAbbreviation)
+      throws DocumentNumberPatternException,
+          DocumentationUnitNotExistsException,
+          DocumentNumberRecyclingException;
 
-  Optional<String> findDeletedDocumentNumber(String documentationOfficeAbbreviation, Year year);
+  String recycleFromDeletedDocumentationUnit(String documentationOfficeAbbreviation, Year year)
+      throws DocumentNumberPatternException, DocumentNumberRecyclingException;
+
+  void assertDocumentationUnitHasNeverBeenHandedOverOrMigrated(UUID documentationUnitId)
+      throws DocumentNumberRecyclingException;
+
+  void assertPatternIsValid(String documentationOfficeAbbreviation, String documentationUnitNumber)
+      throws DocumentNumberPatternException;
+
+  void assertStatusHasNeverBeenPublished(DocumentationUnitDTO documentationUnitDTO)
+      throws DocumentNumberPatternException, DocumentNumberRecyclingException;
 
   void delete(String documentNumber);
 }

--- a/backend/src/main/java/de/bund/digitalservice/ris/caselaw/domain/DocumentNumberRecyclingService.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/caselaw/domain/DocumentNumberRecyclingService.java
@@ -1,6 +1,5 @@
 package de.bund.digitalservice.ris.caselaw.domain;
 
-import de.bund.digitalservice.ris.caselaw.adapter.database.jpa.DocumentationUnitDTO;
 import de.bund.digitalservice.ris.caselaw.domain.exception.DocumentNumberPatternException;
 import de.bund.digitalservice.ris.caselaw.domain.exception.DocumentNumberRecyclingException;
 import de.bund.digitalservice.ris.caselaw.domain.exception.DocumentationUnitNotExistsException;
@@ -23,9 +22,6 @@ public interface DocumentNumberRecyclingService {
 
   void assertPatternIsValid(String documentationOfficeAbbreviation, String documentationUnitNumber)
       throws DocumentNumberPatternException;
-
-  void assertStatusHasNeverBeenPublished(DocumentationUnitDTO documentationUnitDTO)
-      throws DocumentNumberPatternException, DocumentNumberRecyclingException;
 
   void delete(String documentNumber);
 }

--- a/backend/src/main/java/de/bund/digitalservice/ris/caselaw/domain/exception/DocumentNumberRecyclingException.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/caselaw/domain/exception/DocumentNumberRecyclingException.java
@@ -1,0 +1,9 @@
+package de.bund.digitalservice.ris.caselaw.domain.exception;
+
+import java.io.IOException;
+
+public class DocumentNumberRecyclingException extends IOException {
+  public DocumentNumberRecyclingException(String message) {
+    super(message);
+  }
+}

--- a/backend/src/test/java/de/bund/digitalservice/ris/caselaw/adapter/DatabaseDocumentNumberGeneratorServiceTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/caselaw/adapter/DatabaseDocumentNumberGeneratorServiceTest.java
@@ -69,7 +69,6 @@ class DatabaseDocumentNumberGeneratorServiceTest {
           DocumentNumberFormatterException,
           DocumentationUnitExistsException {
     var nextDocumentNumber = generateDefaultDocumentNumber();
-    when(service.recycle(nextDocumentNumber)).thenReturn(Optional.of(nextDocumentNumber));
 
     Assertions.assertEquals(
         service.generateDocumentNumber(DEFAULT_ABBREVIATION), nextDocumentNumber);

--- a/backend/src/test/java/de/bund/digitalservice/ris/caselaw/adapter/DatabaseDocumentNumberRecyclingServiceTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/caselaw/adapter/DatabaseDocumentNumberRecyclingServiceTest.java
@@ -1,6 +1,8 @@
 package de.bund.digitalservice.ris.caselaw.adapter;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import de.bund.digitalservice.ris.caselaw.adapter.database.jpa.DatabaseDeletedDocumentationIdsRepository;
@@ -9,9 +11,15 @@ import de.bund.digitalservice.ris.caselaw.adapter.database.jpa.DeletedDocumentat
 import de.bund.digitalservice.ris.caselaw.adapter.database.jpa.DocumentationUnitDTO;
 import de.bund.digitalservice.ris.caselaw.adapter.database.jpa.StatusDTO;
 import de.bund.digitalservice.ris.caselaw.domain.DateUtil;
+import de.bund.digitalservice.ris.caselaw.domain.EventRecord;
+import de.bund.digitalservice.ris.caselaw.domain.HandoverEntityType;
+import de.bund.digitalservice.ris.caselaw.domain.HandoverService;
 import de.bund.digitalservice.ris.caselaw.domain.PublicationStatus;
+import de.bund.digitalservice.ris.caselaw.domain.exception.DocumentNumberPatternException;
+import de.bund.digitalservice.ris.caselaw.domain.exception.DocumentNumberRecyclingException;
 import java.time.Instant;
 import java.time.Year;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -40,6 +48,8 @@ class DatabaseDocumentNumberRecyclingServiceTest {
 
   @Autowired DatabaseDocumentNumberRecyclingService service;
 
+  @MockBean HandoverService handoverService;
+
   private static final String DEFAULT_DOCUMENTATION_OFFICE = "BGH";
 
   private static String generateDefaultDocumentNumber() {
@@ -47,7 +57,7 @@ class DatabaseDocumentNumberRecyclingServiceTest {
   }
 
   @Test
-  void shouldNotSaveInvalidPrefix() {
+  void addForRecycling_shouldNotSave_ifPrefixIsInvalid() {
 
     var documentationUnitDTO =
         DocumentationUnitDTO.builder()
@@ -72,16 +82,17 @@ class DatabaseDocumentNumberRecyclingServiceTest {
                 DocumentationUnitDTO.builder().statusHistory(List.of(unpublished)).build()));
     when(repository.save(any())).thenReturn(generateDeletedDocumentationUnitDTO());
 
-    var saved =
-        service.addForRecycling(
-            documentationUnitDTO.getId(),
-            documentationUnitDTO.getDocumentNumber(),
-            DEFAULT_DOCUMENTATION_OFFICE);
-    Assertions.assertTrue(saved.isEmpty());
+    assertThrows(
+        DocumentNumberPatternException.class,
+        () ->
+            service.addForRecycling(
+                documentationUnitDTO.getId(),
+                documentationUnitDTO.getDocumentNumber(),
+                DEFAULT_DOCUMENTATION_OFFICE));
   }
 
   @Test
-  void shouldNotOfferInvalidPrefix() {
+  void recycleFromDeletedDocumentationUnit_shouldNotOfferInvalidPrefix() {
     var outdatedDeletedId =
         DeletedDocumentationUnitDTO.builder()
             .documentNumber("KORE2" + Year.now() + "0037")
@@ -92,84 +103,171 @@ class DatabaseDocumentNumberRecyclingServiceTest {
     when(repository.findFirstByAbbreviationAndYear(DEFAULT_DOCUMENTATION_OFFICE, Year.now()))
         .thenReturn(Optional.of(outdatedDeletedId));
 
-    Assertions.assertTrue(
-        service.findDeletedDocumentNumber(DEFAULT_DOCUMENTATION_OFFICE, Year.now()).isEmpty());
+    assertThrows(
+        DocumentNumberPatternException.class,
+        () ->
+            service.recycleFromDeletedDocumentationUnit(DEFAULT_DOCUMENTATION_OFFICE, Year.now()));
+  }
+
+  @Test
+  void recycleFromDeletedDocumentationUnit_shouldNotOfferUsedDocumentationUnit() {
+    var usedDocumentationUnit =
+        DeletedDocumentationUnitDTO.builder()
+            .documentNumber(generateDefaultDocumentNumber())
+            .year(Year.now())
+            .abbreviation(DEFAULT_DOCUMENTATION_OFFICE)
+            .build();
+
+    when(repository.findFirstByAbbreviationAndYear(DEFAULT_DOCUMENTATION_OFFICE, Year.now()))
+        .thenReturn(Optional.of(usedDocumentationUnit));
+
+    when(documentationUnitRepository.findByDocumentNumber(
+            usedDocumentationUnit.getDocumentNumber()))
+        .thenReturn(Optional.of(generateDocumentationUnitDto()));
+
+    var exception =
+        assertThrows(
+            DocumentNumberRecyclingException.class,
+            () ->
+                service.recycleFromDeletedDocumentationUnit(
+                    DEFAULT_DOCUMENTATION_OFFICE, Year.now()));
+
+    Assertions.assertEquals(
+        exception.getMessage(), "Saved documentation number is currently in use");
   }
 
   @ParameterizedTest
   @EnumSource(
       value = PublicationStatus.class,
       names = {"UNPUBLISHED", "EXTERNAL_HANDOVER_PENDING"})
-  void shouldSaveIfOnly_unpublished(PublicationStatus publicationStatus) {
+  void addForRecycling_shouldSaveIfOnly_unpublished(PublicationStatus publicationStatus) {
     var documentationUnitDTO =
         DocumentationUnitDTO.builder()
             .id(UUID.randomUUID())
             .documentNumber(generateDefaultDocumentNumber())
             .build();
 
+    documentationUnitDTO.setStatus(generateStatus(documentationUnitDTO, publicationStatus));
+
     when(documentationUnitRepository.findById(documentationUnitDTO.getId()))
-        .thenReturn(
-            Optional.of(
-                DocumentationUnitDTO.builder()
-                    .status(generateStatus(documentationUnitDTO, publicationStatus))
-                    .statusHistory(List.of(generateStatus(documentationUnitDTO, publicationStatus)))
-                    .build()));
+        .thenReturn(Optional.of(documentationUnitDTO));
 
     when(repository.save(any())).thenReturn(generateDeletedDocumentationUnitDTO());
 
-    var saved =
-        service.addForRecycling(
-            documentationUnitDTO.getId(),
-            documentationUnitDTO.getDocumentNumber(),
-            DEFAULT_DOCUMENTATION_OFFICE);
+    DocumentNumberRecyclingException exception =
+        assertThrows(
+            DocumentNumberRecyclingException.class,
+            () ->
+                service.addForRecycling(
+                    documentationUnitDTO.getId(),
+                    documentationUnitDTO.getDocumentNumber(),
+                    DEFAULT_DOCUMENTATION_OFFICE));
 
-    Assertions.assertTrue(saved.isPresent());
+    Assertions.assertEquals(
+        "Status has been changed once or neither unpublished nor handover pending",
+        exception.getMessage());
   }
 
   @Test
-  void shouldNotSaveIf_published() {
+  void addForRecycling_shouldNotSave_ifHadedOverOrMigrated() {
     var documentationUnitDTO = generateDocumentationUnitDto();
+    //    var unpublished = generateStatus(documentationUnitDTO, PublicationStatus.UNPUBLISHED);
 
+    when(handoverService.getEventLog(
+            documentationUnitDTO.getId(), HandoverEntityType.DOCUMENTATION_UNIT))
+        .thenReturn(List.of(mock(EventRecord.class)));
+
+    when(documentationUnitRepository.findById(documentationUnitDTO.getId()))
+        .thenReturn(
+            Optional.of(
+                DocumentationUnitDTO.builder().statusHistory(Collections.emptyList()).build()));
+
+    DocumentNumberRecyclingException exception =
+        assertThrows(
+            DocumentNumberRecyclingException.class,
+            () ->
+                service.addForRecycling(
+                    documentationUnitDTO.getId(),
+                    documentationUnitDTO.getDocumentNumber(),
+                    DEFAULT_DOCUMENTATION_OFFICE));
+
+    Assertions.assertEquals(
+        "This Documentation unit has already been handed over or migrated and therefore cannot be reused",
+        exception.getMessage());
+  }
+
+  @Test
+  void addForRecycling_shouldNotSave_IfDocumentationUnitHasBeenPublished() {
+    var documentationUnitDTO = generateDocumentationUnitDto();
     var published = generateStatus(documentationUnitDTO, PublicationStatus.PUBLISHED);
 
     when(documentationUnitRepository.findById(documentationUnitDTO.getId()))
         .thenReturn(
-            Optional.of(DocumentationUnitDTO.builder().statusHistory(List.of(published)).build()));
-
-    when(repository.save(any())).thenReturn(generateDeletedDocumentationUnitDTO());
-
-    var saved =
-        service.addForRecycling(
-            documentationUnitDTO.getId(),
-            documentationUnitDTO.getDocumentNumber(),
-            DEFAULT_DOCUMENTATION_OFFICE);
-
-    Assertions.assertTrue(saved.isEmpty());
-  }
-
-  @Test
-  void shouldNotSaveIf_multipleStatus() {
-    var documentationUnitDto = generateDocumentationUnitDto();
-
-    var unpublished = generateStatus(documentationUnitDto, PublicationStatus.UNPUBLISHED);
-    var published = generateStatus(documentationUnitDto, PublicationStatus.PUBLISHED);
-
-    when(documentationUnitRepository.findById(documentationUnitDto.getId()))
-        .thenReturn(
             Optional.of(
                 DocumentationUnitDTO.builder()
-                    .statusHistory(List.of(published, unpublished))
+                    .status(published)
+                    .statusHistory(List.of(published))
                     .build()));
 
     when(repository.save(any())).thenReturn(generateDeletedDocumentationUnitDTO());
 
-    var saved =
-        service.addForRecycling(
-            documentationUnitDto.getId(),
-            documentationUnitDto.getDocumentNumber(),
-            DEFAULT_DOCUMENTATION_OFFICE);
+    DocumentNumberRecyclingException exception =
+        assertThrows(
+            DocumentNumberRecyclingException.class,
+            () ->
+                service.addForRecycling(
+                    documentationUnitDTO.getId(),
+                    documentationUnitDTO.getDocumentNumber(),
+                    DEFAULT_DOCUMENTATION_OFFICE));
 
-    Assertions.assertTrue(saved.isEmpty());
+    Assertions.assertEquals(
+        "Status has been changed once or neither unpublished nor handover pending",
+        exception.getMessage());
+  }
+
+  @Test
+  void addForRecycling_shouldNotSave_ifMultipleStatusExists() {
+    var documentationUnitDto = generateDocumentationUnitDto();
+
+    var statusList =
+        List.of(
+            generateStatus(documentationUnitDto, PublicationStatus.PUBLISHED),
+            generateStatus(documentationUnitDto, PublicationStatus.UNPUBLISHED));
+    documentationUnitDto.setStatus(statusList.get(1));
+    documentationUnitDto.setStatusHistory(statusList);
+
+    when(documentationUnitRepository.findById(documentationUnitDto.getId()))
+        .thenReturn(Optional.of(documentationUnitDto));
+
+    when(repository.save(any())).thenReturn(generateDeletedDocumentationUnitDTO());
+
+    DocumentNumberRecyclingException exception =
+        assertThrows(
+            DocumentNumberRecyclingException.class,
+            () ->
+                service.addForRecycling(
+                    documentationUnitDto.getId(),
+                    documentationUnitDto.getDocumentNumber(),
+                    DEFAULT_DOCUMENTATION_OFFICE));
+
+    Assertions.assertEquals(
+        "Status has been changed once or neither unpublished nor handover pending",
+        exception.getMessage());
+  }
+
+  @Test
+  void assertStatusHasNeverBeenPublished_shouldReturnErrorIfDocumentHasBeenPublishedOrHandedOver() {
+    var documentationUnitDTO = generateDocumentationUnitDto();
+
+    when(handoverService.getEventLog(
+            documentationUnitDTO.getId(), HandoverEntityType.DOCUMENTATION_UNIT))
+        .thenReturn(List.of(mock(EventRecord.class)));
+
+    assertThrows(
+        DocumentNumberRecyclingException.class,
+        () ->
+            service.assertDocumentationUnitHasNeverBeenHandedOverOrMigrated(
+                documentationUnitDTO.getId()));
   }
 
   private static StatusDTO generateStatus(


### PR DESCRIPTION
RISDEV-5186

* Removing optional from service to throw actual errors
* Adding and adjusting tests
* addForRecycling to void
* Adding custom exception
* Empty log in either handover or migration service is required to for recycle. This condition is a must on both recycling and saving