### PR TITLE
Add missing inputs for literature references

### DIFF
--- a/backend/src/main/java/de/bund/digitalservice/ris/caselaw/adapter/DocumentTypeController.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/caselaw/adapter/DocumentTypeController.java
@@ -28,4 +28,11 @@ public class DocumentTypeController {
       @RequestParam(value = "q") Optional<String> searchStr) {
     return service.getDocumentTypes(searchStr);
   }
+
+  @GetMapping(value = "/dependent-literature", produces = MediaType.APPLICATION_JSON_VALUE)
+  @PreAuthorize("isAuthenticated()")
+  public List<DocumentType> getDependentLiteratureDocumentTypes(
+      @RequestParam(value = "q") Optional<String> searchStr) {
+    return service.getDependentLiteratureDocumentTypes(searchStr);
+  }
 }

--- a/backend/src/main/java/de/bund/digitalservice/ris/caselaw/adapter/database/jpa/PostgresDocumentTypeRepositoryImpl.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/caselaw/adapter/database/jpa/PostgresDocumentTypeRepositoryImpl.java
@@ -31,6 +31,25 @@ public class PostgresDocumentTypeRepositoryImpl implements DocumentTypeRepositor
   }
 
   @Override
+  public List<DocumentType> findIndependentLiteratureBySearchStr(String searchString) {
+    return repository
+        .findCaselawBySearchStrAndCategory(
+            searchString, categoryRepository.findFirstByLabel("U").getId())
+        .stream()
+        .map(DocumentTypeTransformer::transformToDomain)
+        .toList();
+  }
+
+  @Override
+  public List<DocumentType> findAllIndependentLiteratureOrderByAbbreviationAscLabelAsc() {
+    return repository
+        .findAllByCategoryOrderByAbbreviationAscLabelAsc(categoryRepository.findFirstByLabel("U"))
+        .stream()
+        .map(DocumentTypeTransformer::transformToDomain)
+        .toList();
+  }
+
+  @Override
   public Optional<DocumentType> findUniqueCaselawBySearchStr(String searchString) {
     return repository
         .findUniqueCaselawBySearchStrAndCategory(

--- a/backend/src/main/java/de/bund/digitalservice/ris/caselaw/domain/DocumentTypeRepository.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/caselaw/domain/DocumentTypeRepository.java
@@ -9,6 +9,10 @@ import org.springframework.data.repository.NoRepositoryBean;
 public interface DocumentTypeRepository {
   List<DocumentType> findCaselawBySearchStr(String searchString);
 
+  List<DocumentType> findIndependentLiteratureBySearchStr(String searchString);
+
+  List<DocumentType> findAllIndependentLiteratureOrderByAbbreviationAscLabelAsc();
+
   Optional<DocumentType> findUniqueCaselawBySearchStr(String searchString);
 
   List<DocumentType> findAllByDocumentTypeOrderByAbbreviationAscLabelAsc(char shortcut);

--- a/backend/src/main/java/de/bund/digitalservice/ris/caselaw/domain/DocumentTypeService.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/caselaw/domain/DocumentTypeService.java
@@ -22,4 +22,12 @@ public class DocumentTypeService {
 
     return documentTypeRepository.findAllByDocumentTypeOrderByAbbreviationAscLabelAsc('R');
   }
+
+  public List<DocumentType> getDependentLiteratureDocumentTypes(Optional<String> searchStr) {
+    if (searchStr.isPresent() && !searchStr.get().isBlank()) {
+      return documentTypeRepository.findIndependentLiteratureBySearchStr(searchStr.get().trim());
+    }
+
+    return documentTypeRepository.findAllIndependentLiteratureOrderByAbbreviationAscLabelAsc();
+  }
 }

--- a/backend/src/test/java/de/bund/digitalservice/ris/caselaw/adapter/DocumentTypeControllerTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/caselaw/adapter/DocumentTypeControllerTest.java
@@ -1,17 +1,18 @@
 package de.bund.digitalservice.ris.caselaw.adapter;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import de.bund.digitalservice.ris.caselaw.TestConfig;
 import de.bund.digitalservice.ris.caselaw.config.SecurityConfig;
 import de.bund.digitalservice.ris.caselaw.domain.DocumentTypeService;
 import de.bund.digitalservice.ris.caselaw.domain.lookuptable.documenttype.DocumentType;
+import de.bund.digitalservice.ris.caselaw.webtestclient.RisWebTestClient;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
-
-import de.bund.digitalservice.ris.caselaw.webtestclient.RisWebTestClient;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -20,9 +21,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
-import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
-
 
 @ExtendWith(SpringExtension.class)
 @WebMvcTest(controllers = DocumentTypeController.class)
@@ -34,14 +33,23 @@ class DocumentTypeControllerTest {
   @MockBean private DocumentTypeService service;
   @MockBean private ClientRegistrationRepository clientRegistrationRepository;
 
-
   private DocumentType documentType1;
   private DocumentType documentType2;
 
   @BeforeEach
   void setUp() {
-    documentType1 = DocumentType.builder().uuid(UUID.randomUUID()).label("label1").jurisShortcut("abbreviation1").build();
-    documentType2 = DocumentType.builder().uuid(UUID.randomUUID()).label("label2").jurisShortcut("abbreviation2").build();
+    documentType1 =
+        DocumentType.builder()
+            .uuid(UUID.randomUUID())
+            .label("label1")
+            .jurisShortcut("abbreviation1")
+            .build();
+    documentType2 =
+        DocumentType.builder()
+            .uuid(UUID.randomUUID())
+            .label("label2")
+            .jurisShortcut("abbreviation2")
+            .build();
   }
 
   @Test
@@ -51,64 +59,69 @@ class DocumentTypeControllerTest {
     when(service.getDocumentTypes(any(Optional.class))).thenReturn(documentTypes);
 
     risWebTestClient
-            .withDefaultLogin()
-            .get()
-            .uri("/api/v1/caselaw/documenttypes")
-            .exchange()
-            .expectStatus()
-            .isOk();
+        .withDefaultLogin()
+        .get()
+        .uri("/api/v1/caselaw/documenttypes")
+        .exchange()
+        .expectStatus()
+        .isOk();
 
     verify(service, times(1)).getDocumentTypes(any(Optional.class));
   }
 
   @Test
-  void shouldReturnListOfDependentLiteratureDocumentTypes_whenGetDependentLiteratureDocumentTypesIsCalled() {
+  void
+      shouldReturnListOfDependentLiteratureDocumentTypes_whenGetDependentLiteratureDocumentTypesIsCalled() {
     List<DocumentType> documentTypes = List.of(documentType1, documentType2);
 
-    when(service.getDependentLiteratureDocumentTypes(any(Optional.class))).thenReturn(documentTypes);
+    when(service.getDependentLiteratureDocumentTypes(any(Optional.class)))
+        .thenReturn(documentTypes);
 
     risWebTestClient
-            .withDefaultLogin()
-            .get()
-            .uri("/api/v1/caselaw/documenttypes/dependent-literature")
-            .exchange()
-            .expectStatus()
-            .isOk();
+        .withDefaultLogin()
+        .get()
+        .uri("/api/v1/caselaw/documenttypes/dependent-literature")
+        .exchange()
+        .expectStatus()
+        .isOk();
 
     verify(service, times(1)).getDependentLiteratureDocumentTypes(any(Optional.class));
-
   }
 
   @Test
-  void shouldCallServiceWithSearchQueryParameter_whenGetDocumentTypesIsCalledWithSearchString() throws Exception {
+  void shouldCallServiceWithSearchQueryParameter_whenGetDocumentTypesIsCalledWithSearchString()
+      throws Exception {
     List<DocumentType> documentTypes = List.of(documentType1, documentType2);
 
     when(service.getDocumentTypes(any(Optional.class))).thenReturn(documentTypes);
 
     risWebTestClient
-            .withDefaultLogin()
-            .get()
-            .uri("/api/v1/caselaw/documenttypes?q=label1")
-            .exchange()
-            .expectStatus()
-            .isOk();
+        .withDefaultLogin()
+        .get()
+        .uri("/api/v1/caselaw/documenttypes?q=label1")
+        .exchange()
+        .expectStatus()
+        .isOk();
 
     verify(service, times(1)).getDocumentTypes(Optional.of("label1"));
   }
 
   @Test
-  void shouldCallServiceWithSearchQueryParameter_whenGetDependentLiteratureDocumentTypesIsCalledWithSearchString() throws Exception {
+  void
+      shouldCallServiceWithSearchQueryParameter_whenGetDependentLiteratureDocumentTypesIsCalledWithSearchString()
+          throws Exception {
     List<DocumentType> documentTypes = List.of(documentType1, documentType2);
 
-    when(service.getDependentLiteratureDocumentTypes(any(Optional.class))).thenReturn(documentTypes);
+    when(service.getDependentLiteratureDocumentTypes(any(Optional.class)))
+        .thenReturn(documentTypes);
 
     risWebTestClient
-            .withDefaultLogin()
-            .get()
-            .uri("/api/v1/caselaw/documenttypes/dependent-literature?q=label2")
-            .exchange()
-            .expectStatus()
-            .isOk();
+        .withDefaultLogin()
+        .get()
+        .uri("/api/v1/caselaw/documenttypes/dependent-literature?q=label2")
+        .exchange()
+        .expectStatus()
+        .isOk();
 
     verify(service, times(1)).getDependentLiteratureDocumentTypes(Optional.of("label2"));
   }

--- a/backend/src/test/java/de/bund/digitalservice/ris/caselaw/adapter/DocumentTypeControllerTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/caselaw/adapter/DocumentTypeControllerTest.java
@@ -1,0 +1,115 @@
+package de.bund.digitalservice.ris.caselaw.adapter;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+import de.bund.digitalservice.ris.caselaw.TestConfig;
+import de.bund.digitalservice.ris.caselaw.config.SecurityConfig;
+import de.bund.digitalservice.ris.caselaw.domain.DocumentTypeService;
+import de.bund.digitalservice.ris.caselaw.domain.lookuptable.documenttype.DocumentType;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import de.bund.digitalservice.ris.caselaw.webtestclient.RisWebTestClient;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+
+@ExtendWith(SpringExtension.class)
+@WebMvcTest(controllers = DocumentTypeController.class)
+@Import({SecurityConfig.class, TestConfig.class})
+class DocumentTypeControllerTest {
+
+  @Autowired private RisWebTestClient risWebTestClient;
+
+  @MockBean private DocumentTypeService service;
+  @MockBean private ClientRegistrationRepository clientRegistrationRepository;
+
+
+  private DocumentType documentType1;
+  private DocumentType documentType2;
+
+  @BeforeEach
+  void setUp() {
+    documentType1 = DocumentType.builder().uuid(UUID.randomUUID()).label("label1").jurisShortcut("abbreviation1").build();
+    documentType2 = DocumentType.builder().uuid(UUID.randomUUID()).label("label2").jurisShortcut("abbreviation2").build();
+  }
+
+  @Test
+  void shouldReturnListOfDocumentTypes_whenGetDocumentTypesIsCalled() throws Exception {
+    List<DocumentType> documentTypes = List.of(documentType1, documentType2);
+
+    when(service.getDocumentTypes(any(Optional.class))).thenReturn(documentTypes);
+
+    risWebTestClient
+            .withDefaultLogin()
+            .get()
+            .uri("/api/v1/caselaw/documenttypes")
+            .exchange()
+            .expectStatus()
+            .isOk();
+
+    verify(service, times(1)).getDocumentTypes(any(Optional.class));
+  }
+
+  @Test
+  void shouldReturnListOfDependentLiteratureDocumentTypes_whenGetDependentLiteratureDocumentTypesIsCalled() {
+    List<DocumentType> documentTypes = List.of(documentType1, documentType2);
+
+    when(service.getDependentLiteratureDocumentTypes(any(Optional.class))).thenReturn(documentTypes);
+
+    risWebTestClient
+            .withDefaultLogin()
+            .get()
+            .uri("/api/v1/caselaw/documenttypes/dependent-literature")
+            .exchange()
+            .expectStatus()
+            .isOk();
+
+    verify(service, times(1)).getDependentLiteratureDocumentTypes(any(Optional.class));
+
+  }
+
+  @Test
+  void shouldCallServiceWithSearchQueryParameter_whenGetDocumentTypesIsCalledWithSearchString() throws Exception {
+    List<DocumentType> documentTypes = List.of(documentType1, documentType2);
+
+    when(service.getDocumentTypes(any(Optional.class))).thenReturn(documentTypes);
+
+    risWebTestClient
+            .withDefaultLogin()
+            .get()
+            .uri("/api/v1/caselaw/documenttypes?q=label1")
+            .exchange()
+            .expectStatus()
+            .isOk();
+
+    verify(service, times(1)).getDocumentTypes(Optional.of("label1"));
+  }
+
+  @Test
+  void shouldCallServiceWithSearchQueryParameter_whenGetDependentLiteratureDocumentTypesIsCalledWithSearchString() throws Exception {
+    List<DocumentType> documentTypes = List.of(documentType1, documentType2);
+
+    when(service.getDependentLiteratureDocumentTypes(any(Optional.class))).thenReturn(documentTypes);
+
+    risWebTestClient
+            .withDefaultLogin()
+            .get()
+            .uri("/api/v1/caselaw/documenttypes/dependent-literature?q=label2")
+            .exchange()
+            .expectStatus()
+            .isOk();
+
+    verify(service, times(1)).getDependentLiteratureDocumentTypes(Optional.of("label2"));
+  }
+}

--- a/backend/src/test/java/de/bund/digitalservice/ris/caselaw/integration/tests/DocumentTypeIntegrationTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/caselaw/integration/tests/DocumentTypeIntegrationTest.java
@@ -78,13 +78,34 @@ class DocumentTypeIntegrationTest {
         .consumeWith(
             response -> {
               assertThat(response.getResponseBody())
-                  .extracting("jurisShortcut", "label")
+                  .extracting("label", "jurisShortcut")
                   .containsExactly(
                       Tuple.tuple("Amtsrechtliche Anordnung", "AmA"),
                       Tuple.tuple("Anordnung", "Ao"),
                       Tuple.tuple("Beschluss", "Bes"),
                       Tuple.tuple("Urteil", "Ur"));
             });
+  }
+
+  @Test
+  void testGetAllDependantLiteratureDocumentTypes() {
+    risWebTestClient
+            .withDefaultLogin()
+            .get()
+            .uri("/api/v1/caselaw/documenttypes/dependent-literature")
+            .exchange()
+            .expectStatus()
+            .isOk()
+            .expectBody(new TypeReference<List<DocumentType>>() {})
+            .consumeWith(
+                    response -> {
+                      assertThat(response.getResponseBody())
+                              .extracting("label", "jurisShortcut")
+                              .containsExactly(
+                                      Tuple.tuple("Anmerkung", "Ean"),
+                                      Tuple.tuple("Entscheidungsbesprechung", "Ebs")
+                              );
+                    });
   }
 
   @Test
@@ -100,10 +121,30 @@ class DocumentTypeIntegrationTest {
         .consumeWith(
             response -> {
               assertThat(response.getResponseBody())
-                  .extracting("jurisShortcut", "label")
+                  .extracting("label", "jurisShortcut")
                   .containsExactly(
-                      Tuple.tuple("Anordnung", "Ao"),
-                      Tuple.tuple("Amtsrechtliche Anordnung", "AmA"));
+                      Tuple.tuple("Amtsrechtliche Anordnung", "AmA"),
+                      Tuple.tuple("Anordnung", "Ao"));
             });
   }
+
+    @Test
+    void testGetDependantLiteratureDocumentTypesWithQuery() {
+        risWebTestClient
+                .withDefaultLogin()
+                .get()
+                .uri("/api/v1/caselaw/documenttypes/dependent-literature?q=Ea")
+                .exchange()
+                .expectStatus()
+                .isOk()
+                .expectBody(new TypeReference<List<DocumentType>>() {})
+                .consumeWith(
+                        response -> {
+                            assertThat(response.getResponseBody())
+                                    .extracting("label", "jurisShortcut")
+                                    .containsExactly(
+                                            Tuple.tuple("Anmerkung", "Ean")
+                            );
+                        });
+    }
 }

--- a/backend/src/test/java/de/bund/digitalservice/ris/caselaw/integration/tests/DocumentTypeIntegrationTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/caselaw/integration/tests/DocumentTypeIntegrationTest.java
@@ -90,22 +90,21 @@ class DocumentTypeIntegrationTest {
   @Test
   void testGetAllDependantLiteratureDocumentTypes() {
     risWebTestClient
-            .withDefaultLogin()
-            .get()
-            .uri("/api/v1/caselaw/documenttypes/dependent-literature")
-            .exchange()
-            .expectStatus()
-            .isOk()
-            .expectBody(new TypeReference<List<DocumentType>>() {})
-            .consumeWith(
-                    response -> {
-                      assertThat(response.getResponseBody())
-                              .extracting("label", "jurisShortcut")
-                              .containsExactly(
-                                      Tuple.tuple("Anmerkung", "Ean"),
-                                      Tuple.tuple("Entscheidungsbesprechung", "Ebs")
-                              );
-                    });
+        .withDefaultLogin()
+        .get()
+        .uri("/api/v1/caselaw/documenttypes/dependent-literature")
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectBody(new TypeReference<List<DocumentType>>() {})
+        .consumeWith(
+            response -> {
+              assertThat(response.getResponseBody())
+                  .extracting("label", "jurisShortcut")
+                  .containsExactly(
+                      Tuple.tuple("Anmerkung", "Ean"),
+                      Tuple.tuple("Entscheidungsbesprechung", "Ebs"));
+            });
   }
 
   @Test
@@ -128,23 +127,21 @@ class DocumentTypeIntegrationTest {
             });
   }
 
-    @Test
-    void testGetDependantLiteratureDocumentTypesWithQuery() {
-        risWebTestClient
-                .withDefaultLogin()
-                .get()
-                .uri("/api/v1/caselaw/documenttypes/dependent-literature?q=Ea")
-                .exchange()
-                .expectStatus()
-                .isOk()
-                .expectBody(new TypeReference<List<DocumentType>>() {})
-                .consumeWith(
-                        response -> {
-                            assertThat(response.getResponseBody())
-                                    .extracting("label", "jurisShortcut")
-                                    .containsExactly(
-                                            Tuple.tuple("Anmerkung", "Ean")
-                            );
-                        });
-    }
+  @Test
+  void testGetDependantLiteratureDocumentTypesWithQuery() {
+    risWebTestClient
+        .withDefaultLogin()
+        .get()
+        .uri("/api/v1/caselaw/documenttypes/dependent-literature?q=Ea")
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectBody(new TypeReference<List<DocumentType>>() {})
+        .consumeWith(
+            response -> {
+              assertThat(response.getResponseBody())
+                  .extracting("label", "jurisShortcut")
+                  .containsExactly(Tuple.tuple("Anmerkung", "Ean"));
+            });
+  }
 }

--- a/backend/src/test/resources/document_types.sql
+++ b/backend/src/test/resources/document_types.sql
@@ -1,43 +1,54 @@
 insert into
-  incremental_migration.document_category (id, label)
+    incremental_migration.document_category (id, label)
 values
-  ('0f382996-497f-4c2f-9a30-1c73d8ac0a88', 'R'),
-  ('11defe05-cd4d-43e5-a07e-06c611b81a28', 'S') on conflict
-do
-  nothing;
+    ('0f382996-497f-4c2f-9a30-1c73d8ac0a88', 'R'),
+    ('4879ae8e-e809-4dd7-8517-d5c795bead79', 'U'),
+    ('11defe05-cd4d-43e5-a07e-06c611b81a28', 'S')
+on conflict do nothing;
 
 insert into
-  incremental_migration.document_type (id, abbreviation, label, document_category_id)
+    incremental_migration.document_type (id, abbreviation, label, document_category_id)
 values
-  (
-    '0f382996-497f-4c2f-9a30-1c73d8ac0a87',
-    'Beschluss',
-    'Bes',
-    '0f382996-497f-4c2f-9a30-1c73d8ac0a88'
-  ),
-  (
-    '11defe05-cd4d-43e5-a07e-06c611b81a26',
-    'Urteil',
-    'Ur',
-    '0f382996-497f-4c2f-9a30-1c73d8ac0a88'
-  ),
-  (
-    '2e5bab9c-8852-49a3-8ed8-08b67399abde',
-    'Anordnung',
-    'Ao',
-    '0f382996-497f-4c2f-9a30-1c73d8ac0a88'
-  ),
-  (
-    '3fc6c738-7e81-40bd-8aa4-c5426605e9b0',
-    'Amtsrechtliche Anordnung',
-    'AmA',
-    '0f382996-497f-4c2f-9a30-1c73d8ac0a88'
-  ),
-  (
-    '1f382996-4924-4c2f-9a30-1c73d8ac0a87',
-    'Andere',
-    'And',
-    '11defe05-cd4d-43e5-a07e-06c611b81a28'
-  ) on conflict
-do
-  nothing;
+    (
+        '0f382996-497f-4c2f-9a30-1c73d8ac0a87',
+        'Bes',
+        'Beschluss',
+        '0f382996-497f-4c2f-9a30-1c73d8ac0a88'
+    ),
+    (
+        '11defe05-cd4d-43e5-a07e-06c611b81a26',
+        'Ur',
+        'Urteil',
+        '0f382996-497f-4c2f-9a30-1c73d8ac0a88'
+    ),
+    (
+        '2e5bab9c-8852-49a3-8ed8-08b67399abde',
+        'Ao',
+        'Anordnung',
+        '0f382996-497f-4c2f-9a30-1c73d8ac0a88'
+    ),
+    (
+        '3fc6c738-7e81-40bd-8aa4-c5426605e9b0',
+        'AmA',
+        'Amtsrechtliche Anordnung',
+        '0f382996-497f-4c2f-9a30-1c73d8ac0a88'
+    ),
+    (
+        '1f382996-4924-4c2f-9a30-1c73d8ac0a87',
+        'And',
+        'Andere',
+        '11defe05-cd4d-43e5-a07e-06c611b81a28'
+    ),
+    (
+        'f718a7ee-f419-46cf-a96a-29227927850c',
+        'Ean',
+        'Anmerkung',
+        '4879ae8e-e809-4dd7-8517-d5c795bead79'
+    ),
+    (
+        '198b276e-8e6d-4df6-8692-44d74ed4fcba',
+        'Ebs',
+        'Entscheidungsbesprechung',
+        '4879ae8e-e809-4dd7-8517-d5c795bead79'
+    )
+on conflict do nothing;

--- a/frontend/src/components/DocumentUnitReferenceInput.vue
+++ b/frontend/src/components/DocumentUnitReferenceInput.vue
@@ -1,7 +1,7 @@
 <script lang="ts" setup>
 import { computed, ref, watch } from "vue"
 import ComboboxInput from "@/components/ComboboxInput.vue"
-import InputField from "@/components/input/InputField.vue"
+import InputField, { LabelPosition } from "@/components/input/InputField.vue"
 import RadioInput from "@/components/input/RadioInput.vue"
 import TextButton from "@/components/input/TextButton.vue"
 import TextInput from "@/components/input/TextInput.vue"
@@ -87,6 +87,41 @@ watch(
 
 <template>
   <div class="flex flex-col gap-24">
+    <div v-if="lastSavedModelValue.isEmpty" class="flex items-center gap-16">
+      <div class="flex items-center">
+        <InputField
+          id="caselaw"
+          class="flex items-center"
+          label="Rechtsprechung"
+          :label-position="LabelPosition.RIGHT"
+        >
+          <RadioInput
+            v-model="reference.referenceType"
+            aria-label="Rechtsprechung Fundstelle"
+            name="referenceType"
+            size="medium"
+            value="caselaw"
+          />
+        </InputField>
+      </div>
+
+      <div class="flex items-center">
+        <InputField
+          id="literature"
+          class="flex items-center"
+          label="Literatur"
+          :label-position="LabelPosition.RIGHT"
+        >
+          <RadioInput
+            v-model="reference.referenceType"
+            aria-label="Literatur Fundstelle"
+            name="referenceType"
+            size="medium"
+            value="literature"
+          />
+        </InputField>
+      </div>
+    </div>
     <InputField
       id="legalPeriodical"
       v-slot="slotProps"
@@ -103,35 +138,7 @@ watch(
         @focus="validationStore.remove('legalPeriodical')"
       ></ComboboxInput>
     </InputField>
-    <div class="flex items-center gap-16">
-      <div class="flex items-center">
-        <InputField
-          id="caselaw"
-          class="flex items-center"
-          label="Rechtsprechung"
-        >
-          <RadioInput
-            v-model="reference.referenceType"
-            aria-label="Rechtsprechung Fundstelle"
-            name="referenceType"
-            size="medium"
-            value="caselaw"
-          />
-        </InputField>
-      </div>
 
-      <div class="flex items-center">
-        <InputField id="literature" class="flex items-center" label="Literatur">
-          <RadioInput
-            v-model="reference.referenceType"
-            aria-label="Literatur Fundstelle"
-            name="referenceType"
-            size="medium"
-            value="literature"
-          />
-        </InputField>
-      </div>
-    </div>
     <div class="flex flex-col gap-24">
       <div class="flex justify-between gap-24">
         <div class="flex w-full flex-col">
@@ -185,18 +192,19 @@ watch(
           ></ComboboxInput>
         </InputField>
       </div>
-      <InputField
+      <div
         v-if="reference.referenceType === 'literature'"
-        id="literatureReferenceDocumentType"
-        label="Autor *"
+        class="w-[calc(50%-10px)]"
       >
-        <TextInput
-          id="literatureReferenceDocumentType"
-          v-model="reference.author"
-          aria-label="Autor Literaturfundstelle"
-          size="medium"
-        ></TextInput>
-      </InputField>
+        <InputField id="literatureReferenceDocumentType" label="Autor *">
+          <TextInput
+            id="literatureReferenceDocumentType"
+            v-model="reference.author"
+            aria-label="Autor Literaturfundstelle"
+            size="medium"
+          ></TextInput>
+        </InputField>
+      </div>
     </div>
     <div class="flex w-full flex-row justify-between">
       <div>

--- a/frontend/src/components/DocumentUnitReferenceInput.vue
+++ b/frontend/src/components/DocumentUnitReferenceInput.vue
@@ -103,7 +103,7 @@ watch(
         @focus="validationStore.remove('legalPeriodical')"
       ></ComboboxInput>
     </InputField>
-    <div class="flex flex-row items-center gap-16">
+    <div class="flex items-center gap-16">
       <div class="flex items-center">
         <InputField
           id="caselaw"
@@ -112,6 +112,7 @@ watch(
         >
           <RadioInput
             v-model="reference.referenceType"
+            aria-label="Rechtsprechung Fundstelle"
             name="referenceType"
             size="medium"
             value="caselaw"
@@ -123,6 +124,7 @@ watch(
         <InputField id="literature" class="flex items-center" label="Literatur">
           <RadioInput
             v-model="reference.referenceType"
+            aria-label="Literatur Fundstelle"
             name="referenceType"
             size="medium"
             value="literature"
@@ -191,7 +193,7 @@ watch(
         <TextInput
           id="literatureReferenceDocumentType"
           v-model="reference.author"
-          aria-label="Klammernzusatz"
+          aria-label="Autor Literaturfundstelle"
           size="medium"
         ></TextInput>
       </InputField>

--- a/frontend/src/components/DocumentUnitReferenceInput.vue
+++ b/frontend/src/components/DocumentUnitReferenceInput.vue
@@ -2,6 +2,7 @@
 import { computed, ref, watch } from "vue"
 import ComboboxInput from "@/components/ComboboxInput.vue"
 import InputField from "@/components/input/InputField.vue"
+import RadioInput from "@/components/input/RadioInput.vue"
 import TextButton from "@/components/input/TextButton.vue"
 import TextInput from "@/components/input/TextInput.vue"
 import { useValidationStore } from "@/composables/useValidationStore"
@@ -102,9 +103,36 @@ watch(
         @focus="validationStore.remove('legalPeriodical')"
       ></ComboboxInput>
     </InputField>
+    <div class="flex flex-row items-center gap-16">
+      <div class="flex items-center">
+        <InputField
+          id="caselaw"
+          class="flex items-center"
+          label="Rechtsprechung"
+        >
+          <RadioInput
+            v-model="reference.referenceType"
+            name="referenceType"
+            size="medium"
+            value="caselaw"
+          />
+        </InputField>
+      </div>
+
+      <div class="flex items-center">
+        <InputField id="literature" class="flex items-center" label="Literatur">
+          <RadioInput
+            v-model="reference.referenceType"
+            name="referenceType"
+            size="medium"
+            value="literature"
+          />
+        </InputField>
+      </div>
+    </div>
     <div class="flex flex-col gap-24">
       <div class="flex justify-between gap-24">
-        <div class="flex-1">
+        <div class="flex w-full flex-col">
           <InputField
             id="citation"
             v-slot="slotProps"
@@ -125,9 +153,9 @@ watch(
           >
         </div>
         <InputField
+          v-if="reference.referenceType === 'caselaw'"
           id="referenceSupplement"
           v-slot="slotProps"
-          class="flex-1"
           label="Klammernzusatz"
           :validation-error="validationStore.getByField('referenceSupplement')"
         >
@@ -140,7 +168,33 @@ watch(
             @focus="validationStore.remove('referenceSupplement')"
           ></TextInput>
         </InputField>
+        <InputField
+          v-if="reference.referenceType === 'literature'"
+          id="literatureReferenceDocumentType"
+          label="Dokumenttyp *"
+        >
+          <ComboboxInput
+            id="literatureReferenceDocumentType"
+            v-model="reference.documentType"
+            aria-label="Dokumenttyp Literaturfundstelle"
+            :item-service="
+              ComboboxItemService.getDependentLiteratureDocumentTypes
+            "
+          ></ComboboxInput>
+        </InputField>
       </div>
+      <InputField
+        v-if="reference.referenceType === 'literature'"
+        id="literatureReferenceDocumentType"
+        label="Autor *"
+      >
+        <TextInput
+          id="literatureReferenceDocumentType"
+          v-model="reference.author"
+          aria-label="Klammernzusatz"
+          size="medium"
+        ></TextInput>
+      </InputField>
     </div>
     <div class="flex w-full flex-row justify-between">
       <div>

--- a/frontend/src/components/periodical-evaluation/references/PeriodicalEditionReferenceInput.vue
+++ b/frontend/src/components/periodical-evaluation/references/PeriodicalEditionReferenceInput.vue
@@ -316,6 +316,7 @@ onMounted(async () => {
         >
           <RadioInput
             v-model="reference.referenceType"
+            aria-label="Rechtsprechung Fundstelle"
             name="referenceType"
             size="medium"
             value="caselaw"
@@ -327,6 +328,7 @@ onMounted(async () => {
         <InputField id="literature" class="flex items-center" label="Literatur">
           <RadioInput
             v-model="reference.referenceType"
+            aria-label="Literatur Fundstelle"
             name="referenceType"
             size="medium"
             value="literature"
@@ -432,13 +434,13 @@ onMounted(async () => {
     </div>
     <InputField
       v-if="reference.referenceType === 'literature'"
-      id="literatureReferenceDocumentType"
+      id="literatureReferenceAuthor"
       label="Autor *"
     >
       <TextInput
-        id="literatureReferenceDocumentType"
+        id="literatureReferenceAuthor"
         v-model="reference.author"
-        aria-label="Klammernzusatz"
+        aria-label="Autor Literaturfundstelle"
         size="medium"
       ></TextInput>
     </InputField>

--- a/frontend/src/components/periodical-evaluation/references/PeriodicalEditionReferenceInput.vue
+++ b/frontend/src/components/periodical-evaluation/references/PeriodicalEditionReferenceInput.vue
@@ -5,7 +5,7 @@ import CreateNewFromSearch from "@/components/CreateNewFromSearch.vue"
 import DecisionSummary from "@/components/DecisionSummary.vue"
 import { DisplayMode } from "@/components/enumDisplayMode"
 import DateInput from "@/components/input/DateInput.vue"
-import InputField from "@/components/input/InputField.vue"
+import InputField, { LabelPosition } from "@/components/input/InputField.vue"
 import RadioInput from "@/components/input/RadioInput.vue"
 import TextButton from "@/components/input/TextButton.vue"
 import TextInput from "@/components/input/TextInput.vue"
@@ -285,7 +285,7 @@ onMounted(async () => {
 </script>
 
 <template>
-  <div class="flex flex-col gap-24 border-b-1">
+  <div class="flex flex-col border-b-1">
     <PopupModal
       v-if="showModal"
       aria-label="Eintrag löschen"
@@ -298,316 +298,331 @@ onMounted(async () => {
       @close-modal="deleteReference"
       @confirm-action="deleteReferenceAndDocUnit"
     />
-    <DecisionSummary
-      v-if="
-        reference.documentationUnit &&
-        reference.documentationUnit?.documentNumber
-      "
-      data-testid="reference-input-summary"
-      :decision="reference.documentationUnit"
-      :display-mode="DisplayMode.SIDEPANEL"
-    />
-    <div class="flex items-center gap-16">
-      <div class="flex items-center">
-        <InputField
-          id="caselaw"
-          class="flex items-center"
-          label="Rechtsprechung"
-        >
-          <RadioInput
-            v-model="reference.referenceType"
-            aria-label="Rechtsprechung Fundstelle"
-            name="referenceType"
-            size="medium"
-            value="caselaw"
-          />
-        </InputField>
-      </div>
+    <h2 class="ds-label-01-bold mb-16">Fundstelle bearbeiten</h2>
+    <div class="flex flex-col gap-24">
+      <DecisionSummary
+        v-if="
+          reference.documentationUnit &&
+          reference.documentationUnit?.documentNumber
+        "
+        data-testid="reference-input-summary"
+        :decision="reference.documentationUnit"
+        :display-mode="DisplayMode.SIDEPANEL"
+      />
+      <div v-if="!isSaved" class="flex items-center gap-16">
+        <div class="flex items-center">
+          <InputField
+            id="caselaw"
+            class="flex items-center"
+            label="Rechtsprechung"
+            :label-position="LabelPosition.RIGHT"
+          >
+            <RadioInput
+              v-model="reference.referenceType"
+              aria-label="Rechtsprechung Fundstelle"
+              name="referenceType"
+              size="medium"
+              value="caselaw"
+            />
+          </InputField>
+        </div>
 
-      <div class="flex items-center">
-        <InputField id="literature" class="flex items-center" label="Literatur">
-          <RadioInput
-            v-model="reference.referenceType"
-            aria-label="Literatur Fundstelle"
-            name="referenceType"
-            size="medium"
-            value="literature"
-          />
-        </InputField>
-      </div>
-    </div>
-    <div class="flex justify-between gap-24">
-      <div id="citationInputField" class="flex w-full flex-col">
-        <InputField
-          v-if="!isSaved"
-          id="citation"
-          v-slot="slotProps"
-          label="Zitatstelle *"
-          :validation-error="validationStore.getByField('citation')"
-        >
-          <div class="flex flex-grow flex-row gap-16">
-            <TextInput
-              id="citation prefix"
-              v-model="prefix"
-              aria-label="Zitatstelle Präfix"
-              placeholder="Präfix"
-              read-only
+        <div class="flex items-center">
+          <InputField
+            id="literature"
+            class="flex items-center"
+            label="Literatur"
+            :label-position="LabelPosition.RIGHT"
+          >
+            <RadioInput
+              v-model="reference.referenceType"
+              aria-label="Literatur Fundstelle"
+              name="referenceType"
               size="medium"
-            ></TextInput>
-            <TextInput
-              id="citation"
-              v-model="reference.citation"
-              aria-label="Zitatstelle *"
-              :has-error="slotProps.hasError"
-              placeholder="Variable"
-              size="medium"
-              @blur="validateRequiredInput(reference)"
-              @focus="validationStore.remove('citation')"
-            ></TextInput>
-            <TextInput
-              id="citation suffix"
-              v-model="suffix"
-              aria-label="Zitatstelle Suffix"
-              placeholder="Suffix"
-              read-only
-              size="medium"
-            ></TextInput>
-          </div>
-        </InputField>
-
-        <InputField
-          v-else
-          id="citation"
-          v-slot="slotProps"
-          label="Zitatstelle *"
-          :validation-error="validationStore.getByField('citation')"
-        >
-          <div class="flex flex-grow flex-row gap-16">
-            <TextInput
-              id="citation"
-              v-model="reference.citation"
-              aria-label="Zitatstelle *"
-              :has-error="slotProps.hasError"
-              size="medium"
-              @blur="validateRequiredInput(reference)"
-              @focus="validationStore.remove('citation')"
-            ></TextInput>
-          </div>
-        </InputField>
-
-        <div v-if="legalPeriodical" class="ds-label-03-reg pt-4">
-          Zitierbeispiel: {{ legalPeriodical.value.citationStyle }}
+              value="literature"
+            />
+          </InputField>
         </div>
       </div>
-
-      <InputField
-        v-if="reference.referenceType === 'caselaw'"
-        id="referenceSupplement"
-        v-slot="slotProps"
-        label="Klammernzusatz *"
-        :validation-error="validationStore.getByField('referenceSupplement')"
-      >
-        <TextInput
-          id="referenceSupplement"
-          v-model="reference.referenceSupplement"
-          aria-label="Klammernzusatz"
-          :has-error="slotProps.hasError"
-          size="medium"
-          @blur="validateRequiredInput(reference)"
-          @focus="validationStore.remove('referenceSupplement')"
-        ></TextInput>
-      </InputField>
-      <InputField
-        v-if="reference.referenceType === 'literature'"
-        id="literatureReferenceDocumentType"
-        label="Dokumenttyp *"
-      >
-        <ComboboxInput
-          id="literatureReferenceDocumentType"
-          v-model="reference.documentType"
-          aria-label="Dokumenttyp Literaturfundstelle"
-          :item-service="
-            ComboboxItemService.getDependentLiteratureDocumentTypes
-          "
-        ></ComboboxInput>
-      </InputField>
-    </div>
-    <InputField
-      v-if="reference.referenceType === 'literature'"
-      id="literatureReferenceAuthor"
-      label="Autor *"
-    >
-      <TextInput
-        id="literatureReferenceAuthor"
-        v-model="reference.author"
-        aria-label="Autor Literaturfundstelle"
-        size="medium"
-      ></TextInput>
-    </InputField>
-
-    <div v-if="!isSaved" id="documentationUnit" class="flex flex-col gap-24">
       <div class="flex justify-between gap-24">
-        <InputField
-          id="courtInput"
-          v-slot="slotProps"
-          label="Gericht"
-          :validation-error="validationStore.getByField('court')"
-        >
-          <ComboboxInput
-            id="courtInput"
-            v-model="relatedDocumentationUnit.court"
-            aria-label="Gericht"
-            clear-on-choosing-item
-            :has-error="slotProps.hasError"
-            :item-service="ComboboxItemService.getCourts"
-            :read-only="reference?.documentationUnit?.hasForeignSource"
-            @focus="validationStore.remove('court')"
+        <div id="citationInputField" class="flex w-full flex-col">
+          <InputField
+            v-if="!isSaved"
+            id="citation"
+            v-slot="slotProps"
+            label="Zitatstelle *"
+            :validation-error="validationStore.getByField('citation')"
           >
-          </ComboboxInput>
-        </InputField>
+            <div class="flex flex-grow flex-row gap-16">
+              <TextInput
+                id="citation prefix"
+                v-model="prefix"
+                aria-label="Zitatstelle Präfix"
+                placeholder="Präfix"
+                read-only
+                size="medium"
+              ></TextInput>
+              <TextInput
+                id="citation"
+                v-model="reference.citation"
+                aria-label="Zitatstelle *"
+                :has-error="slotProps.hasError"
+                placeholder="Variable"
+                size="medium"
+                @blur="validateRequiredInput(reference)"
+                @focus="validationStore.remove('citation')"
+              ></TextInput>
+              <TextInput
+                id="citation suffix"
+                v-model="suffix"
+                aria-label="Zitatstelle Suffix"
+                placeholder="Suffix"
+                read-only
+                size="medium"
+              ></TextInput>
+            </div>
+          </InputField>
+
+          <InputField
+            v-else
+            id="citation"
+            v-slot="slotProps"
+            label="Zitatstelle *"
+            :validation-error="validationStore.getByField('citation')"
+          >
+            <div class="flex flex-grow flex-row gap-16">
+              <TextInput
+                id="citation"
+                v-model="reference.citation"
+                aria-label="Zitatstelle *"
+                :has-error="slotProps.hasError"
+                size="medium"
+                @blur="validateRequiredInput(reference)"
+                @focus="validationStore.remove('citation')"
+              ></TextInput>
+            </div>
+          </InputField>
+
+          <div v-if="legalPeriodical" class="ds-label-03-reg pt-4">
+            Zitierbeispiel: {{ legalPeriodical.value.citationStyle }}
+          </div>
+        </div>
+
         <InputField
-          id="decisionDate"
+          v-if="reference.referenceType === 'caselaw'"
+          id="referenceSupplement"
           v-slot="slotProps"
-          label="Entscheidungsdatum"
-          :validation-error="validationStore.getByField('decisionDate')"
-          @update:validation-error="
-            (validationError: any) =>
-              updateDateFormatValidation(validationError)
-          "
-        >
-          <DateInput
-            id="decisionDate"
-            v-model="relatedDocumentationUnit.decisionDate"
-            aria-label="Entscheidungsdatum"
-            class="ds-input-medium"
-            :has-error="slotProps.hasError"
-            :read-only="reference?.documentationUnit?.hasForeignSource"
-            @focus="validationStore.remove('decisionDate')"
-            @update:validation-error="slotProps.updateValidationError"
-          ></DateInput>
-        </InputField>
-      </div>
-      <div class="flex justify-between gap-24">
-        <InputField
-          id="fileNumber"
-          v-slot="slotProps"
-          label="Aktenzeichen"
-          :validation-error="validationStore.getByField('fileNumber')"
+          label="Klammernzusatz *"
+          :validation-error="validationStore.getByField('referenceSupplement')"
         >
           <TextInput
-            id="fileNumber"
-            v-model="relatedDocumentationUnit.fileNumber"
-            aria-label="Aktenzeichen"
+            id="referenceSupplement"
+            v-model="reference.referenceSupplement"
+            aria-label="Klammernzusatz"
             :has-error="slotProps.hasError"
-            :read-only="reference?.documentationUnit?.hasForeignSource"
             size="medium"
-            @focus="validationStore.remove('fileNumber')"
+            @blur="validateRequiredInput(reference)"
+            @focus="validationStore.remove('referenceSupplement')"
           ></TextInput>
         </InputField>
         <InputField
-          id="decisionDocumentType"
-          label="Dokumenttyp"
-          :validation-error="validationStore.getByField('documentType')"
+          v-if="reference.referenceType === 'literature'"
+          id="literatureReferenceDocumentType"
+          label="Dokumenttyp *"
         >
           <ComboboxInput
-            id="decisionDocumentType"
-            v-model="relatedDocumentationUnit.documentType"
-            aria-label="Dokumenttyp"
-            :item-service="ComboboxItemService.getDocumentTypes"
-            :read-only="reference?.documentationUnit?.hasForeignSource"
+            id="literatureReferenceDocumentType"
+            v-model="reference.documentType"
+            aria-label="Dokumenttyp Literaturfundstelle"
+            :item-service="
+              ComboboxItemService.getDependentLiteratureDocumentTypes
+            "
           ></ComboboxInput>
         </InputField>
       </div>
-    </div>
+      <div
+        v-if="reference.referenceType === 'literature'"
+        class="w-[calc(50%-10px)]"
+      >
+        <InputField id="literatureReferenceAuthor" label="Autor *">
+          <TextInput
+            id="literatureReferenceAuthor"
+            v-model="reference.author"
+            aria-label="Autor Literaturfundstelle"
+            size="medium"
+          ></TextInput>
+        </InputField>
+      </div>
 
-    <div class="flex w-full flex-row justify-between">
-      <div>
-        <div class="flex gap-16">
+      <div v-if="!isSaved" id="documentationUnit">
+        <h2 class="ds-label-01-bold mb-16">Entscheidung hinzufügen</h2>
+
+        <div class="flex flex-col gap-24">
+          <div class="flex justify-between gap-24">
+            <InputField
+              id="courtInput"
+              v-slot="slotProps"
+              label="Gericht"
+              :validation-error="validationStore.getByField('court')"
+            >
+              <ComboboxInput
+                id="courtInput"
+                v-model="relatedDocumentationUnit.court"
+                aria-label="Gericht"
+                clear-on-choosing-item
+                :has-error="slotProps.hasError"
+                :item-service="ComboboxItemService.getCourts"
+                :read-only="reference?.documentationUnit?.hasForeignSource"
+                @focus="validationStore.remove('court')"
+              >
+              </ComboboxInput>
+            </InputField>
+            <InputField
+              id="decisionDate"
+              v-slot="slotProps"
+              label="Entscheidungsdatum"
+              :validation-error="validationStore.getByField('decisionDate')"
+              @update:validation-error="
+                (validationError: any) =>
+                  updateDateFormatValidation(validationError)
+              "
+            >
+              <DateInput
+                id="decisionDate"
+                v-model="relatedDocumentationUnit.decisionDate"
+                aria-label="Entscheidungsdatum"
+                class="ds-input-medium"
+                :has-error="slotProps.hasError"
+                :read-only="reference?.documentationUnit?.hasForeignSource"
+                @focus="validationStore.remove('decisionDate')"
+                @update:validation-error="slotProps.updateValidationError"
+              ></DateInput>
+            </InputField>
+          </div>
+
+          <div class="flex justify-between gap-24">
+            <InputField
+              id="fileNumber"
+              v-slot="slotProps"
+              label="Aktenzeichen"
+              :validation-error="validationStore.getByField('fileNumber')"
+            >
+              <TextInput
+                id="fileNumber"
+                v-model="relatedDocumentationUnit.fileNumber"
+                aria-label="Aktenzeichen"
+                :has-error="slotProps.hasError"
+                :read-only="reference?.documentationUnit?.hasForeignSource"
+                size="medium"
+                @focus="validationStore.remove('fileNumber')"
+              ></TextInput>
+            </InputField>
+            <InputField
+              id="decisionDocumentType"
+              label="Dokumenttyp"
+              :validation-error="validationStore.getByField('documentType')"
+            >
+              <ComboboxInput
+                id="decisionDocumentType"
+                v-model="relatedDocumentationUnit.documentType"
+                aria-label="Dokumenttyp"
+                :item-service="ComboboxItemService.getDocumentTypes"
+                :read-only="reference?.documentationUnit?.hasForeignSource"
+              ></ComboboxInput>
+            </InputField>
+          </div>
+        </div>
+      </div>
+
+      <div class="flex w-full flex-row justify-between">
+        <div>
+          <div class="flex gap-16">
+            <TextButton
+              v-if="!isSaved"
+              aria-label="Nach Entscheidung suchen"
+              button-type="primary"
+              label="Suchen"
+              size="small"
+              @click="search"
+            />
+            <TextButton
+              v-if="isSaved"
+              aria-label="Fundstelle vermerken"
+              button-type="tertiary"
+              data-testid="previous-decision-save-button"
+              :disabled="reference.isEmpty"
+              label="Übernehmen"
+              size="small"
+              @click.stop="addReference(relatedDocumentationUnit)"
+            />
+            <TextButton
+              v-if="isSaved"
+              aria-label="Abbrechen"
+              button-type="ghost"
+              label="Abbrechen"
+              size="small"
+              @click.stop="emit('cancelEdit')"
+            />
+          </div>
+        </div>
+        <div v-if="isSaved">
           <TextButton
-            v-if="!isSaved"
-            aria-label="Nach Entscheidung suchen"
-            button-type="primary"
-            label="Suchen"
+            v-if="
+              reference?.documentationUnit?.status?.publicationStatus ===
+                PublicationState.UNPUBLISHED &&
+              reference?.getIsDocumentationUnitCreatedByReference()
+            "
+            aria-label="Eintrag löschen"
+            button-type="destructive"
+            label="Eintrag löschen"
             size="small"
-            @click="search"
+            @click.stop="toggleDeletionConfirmationModal"
+          />
+
+          <TextButton
+            v-else-if="
+              reference.documentationUnit?.status?.publicationStatus ===
+                PublicationState.EXTERNAL_HANDOVER_PENDING &&
+              reference?.getIsDocumentationUnitCreatedByReference()
+            "
+            aria-label="Fundstelle und Dokumentationseinheit löschen"
+            button-type="destructive"
+            label="Fundstelle und Dokumentationseinheit löschen"
+            size="small"
+            @click.stop="deleteReferenceAndDocUnit"
           />
           <TextButton
-            v-if="isSaved"
-            aria-label="Fundstelle vermerken"
-            button-type="tertiary"
-            data-testid="previous-decision-save-button"
-            :disabled="reference.isEmpty"
-            label="Übernehmen"
+            v-else
+            aria-label="Eintrag löschen"
+            button-type="destructive"
+            label="Eintrag löschen"
             size="small"
-            @click.stop="addReference(relatedDocumentationUnit)"
-          />
-          <TextButton
-            v-if="isSaved"
-            aria-label="Abbrechen"
-            button-type="ghost"
-            label="Abbrechen"
-            size="small"
-            @click.stop="emit('cancelEdit')"
+            @click.stop="modelValue && emit('removeEntry', modelValue)"
           />
         </div>
       </div>
-      <div v-if="isSaved">
-        <TextButton
-          v-if="
-            reference?.documentationUnit?.status?.publicationStatus ===
-              PublicationState.UNPUBLISHED &&
-            reference?.getIsDocumentationUnitCreatedByReference()
-          "
-          aria-label="Eintrag löschen"
-          button-type="destructive"
-          label="Eintrag löschen"
-          size="small"
-          @click.stop="toggleDeletionConfirmationModal"
-        />
-
-        <TextButton
-          v-else-if="
-            reference.documentationUnit?.status?.publicationStatus ===
-              PublicationState.EXTERNAL_HANDOVER_PENDING &&
-            reference?.getIsDocumentationUnitCreatedByReference()
-          "
-          aria-label="Fundstelle und Dokumentationseinheit löschen"
-          button-type="destructive"
-          label="Fundstelle und Dokumentationseinheit löschen"
-          size="small"
-          @click.stop="deleteReferenceAndDocUnit"
-        />
-        <TextButton
-          v-else
-          aria-label="Eintrag löschen"
-          button-type="destructive"
-          label="Eintrag löschen"
-          size="small"
-          @click.stop="modelValue && emit('removeEntry', modelValue)"
-        />
+      <div v-if="isLoading || searchResults" class="bg-blue-200">
+        <Pagination
+          navigation-position="bottom"
+          :page="searchResultsCurrentPage"
+          @update-page="updatePage"
+        >
+          <SearchResultList
+            allow-multiple-links
+            :display-mode="DisplayMode.SIDEPANEL"
+            :is-loading="isLoading"
+            :search-results="searchResults"
+            @link-decision="addReference"
+          />
+        </Pagination>
       </div>
+      <CreateNewFromSearch
+        v-if="searchResults && featureToggle"
+        :parameters="createDocumentationUnitParameters"
+        :validate-required-input="() => validateRequiredInput(reference)"
+        @created-documentation-unit="addReferenceWithCreatedDocunit"
+      />
     </div>
-    <div v-if="isLoading || searchResults" class="bg-blue-200">
-      <Pagination
-        navigation-position="bottom"
-        :page="searchResultsCurrentPage"
-        @update-page="updatePage"
-      >
-        <SearchResultList
-          allow-multiple-links
-          :display-mode="DisplayMode.SIDEPANEL"
-          :is-loading="isLoading"
-          :search-results="searchResults"
-          @link-decision="addReference"
-        />
-      </Pagination>
-    </div>
-    <CreateNewFromSearch
-      v-if="searchResults && featureToggle"
-      :parameters="createDocumentationUnitParameters"
-      :validate-required-input="() => validateRequiredInput(reference)"
-      @created-documentation-unit="addReferenceWithCreatedDocunit"
-    />
   </div>
 </template>
 @/stores/editionStore

--- a/frontend/src/components/periodical-evaluation/references/PeriodicalEditionReferenceInput.vue
+++ b/frontend/src/components/periodical-evaluation/references/PeriodicalEditionReferenceInput.vue
@@ -11,6 +11,7 @@ import TextInput from "@/components/input/TextInput.vue"
 import { ValidationError } from "@/components/input/types"
 import Pagination, { Page } from "@/components/Pagination.vue"
 import PopupModal from "@/components/PopupModal.vue"
+import RadioInput from "@/components/input/RadioInput.vue"
 import SearchResultList, {
   SearchResults,
 } from "@/components/SearchResultList.vue"
@@ -306,8 +307,35 @@ onMounted(async () => {
       :decision="reference.documentationUnit"
       :display-mode="DisplayMode.SIDEPANEL"
     />
+    <div class="flex items-center gap-16">
+      <div class="flex items-center">
+        <InputField
+          id="caselaw"
+          label="Rechtsprechung"
+          class="flex items-center"
+        >
+          <RadioInput
+            v-model="reference.referenceType"
+            name="referenceType"
+            size="medium"
+            value="caselaw"
+          />
+        </InputField>
+      </div>
+
+      <div class="flex items-center">
+        <InputField id="literature" label="Literatur" class="flex items-center">
+          <RadioInput
+            v-model="reference.referenceType"
+            name="referenceType"
+            size="medium"
+            value="literature"
+          />
+        </InputField>
+      </div>
+    </div>
     <div class="flex justify-between gap-24">
-      <div id="citationInputField" class="flex-1">
+      <div id="citationInputField" class="flex w-full flex-col">
         <InputField
           v-if="!isSaved"
           id="citation"
@@ -372,8 +400,8 @@ onMounted(async () => {
 
       <InputField
         id="referenceSupplement"
+        v-if="reference.referenceType === 'caselaw'"
         v-slot="slotProps"
-        class="flex-1"
         label="Klammernzusatz *"
         :validation-error="validationStore.getByField('referenceSupplement')"
       >
@@ -387,7 +415,31 @@ onMounted(async () => {
           @focus="validationStore.remove('referenceSupplement')"
         ></TextInput>
       </InputField>
+      <InputField
+        id="literatureReferenceDocumentType"
+        v-if="reference.referenceType === 'literature'"
+        label="Dokumenttyp *"
+      >
+        <ComboboxInput
+          id="literatureReferenceDocumentType"
+          v-model="reference.documentType"
+          aria-label="Dokumenttyp Literaturfundstelle"
+          :item-service="ComboboxItemService.getDocumentTypes"
+        ></ComboboxInput>
+      </InputField>
     </div>
+    <InputField
+      id="literatureReferenceDocumentType"
+      v-if="reference.referenceType === 'literature'"
+      label="Autor *"
+    >
+      <TextInput
+        id="literatureReferenceDocumentType"
+        v-model="reference.author"
+        aria-label="Klammernzusatz"
+        size="medium"
+      ></TextInput>
+    </InputField>
 
     <div v-if="!isSaved" id="documentationUnit" class="flex flex-col gap-24">
       <div class="flex justify-between gap-24">

--- a/frontend/src/components/periodical-evaluation/references/PeriodicalEditionReferenceInput.vue
+++ b/frontend/src/components/periodical-evaluation/references/PeriodicalEditionReferenceInput.vue
@@ -6,12 +6,12 @@ import DecisionSummary from "@/components/DecisionSummary.vue"
 import { DisplayMode } from "@/components/enumDisplayMode"
 import DateInput from "@/components/input/DateInput.vue"
 import InputField from "@/components/input/InputField.vue"
+import RadioInput from "@/components/input/RadioInput.vue"
 import TextButton from "@/components/input/TextButton.vue"
 import TextInput from "@/components/input/TextInput.vue"
 import { ValidationError } from "@/components/input/types"
 import Pagination, { Page } from "@/components/Pagination.vue"
 import PopupModal from "@/components/PopupModal.vue"
-import RadioInput from "@/components/input/RadioInput.vue"
 import SearchResultList, {
   SearchResults,
 } from "@/components/SearchResultList.vue"
@@ -311,8 +311,8 @@ onMounted(async () => {
       <div class="flex items-center">
         <InputField
           id="caselaw"
-          label="Rechtsprechung"
           class="flex items-center"
+          label="Rechtsprechung"
         >
           <RadioInput
             v-model="reference.referenceType"
@@ -324,7 +324,7 @@ onMounted(async () => {
       </div>
 
       <div class="flex items-center">
-        <InputField id="literature" label="Literatur" class="flex items-center">
+        <InputField id="literature" class="flex items-center" label="Literatur">
           <RadioInput
             v-model="reference.referenceType"
             name="referenceType"
@@ -399,8 +399,8 @@ onMounted(async () => {
       </div>
 
       <InputField
-        id="referenceSupplement"
         v-if="reference.referenceType === 'caselaw'"
+        id="referenceSupplement"
         v-slot="slotProps"
         label="Klammernzusatz *"
         :validation-error="validationStore.getByField('referenceSupplement')"
@@ -416,21 +416,23 @@ onMounted(async () => {
         ></TextInput>
       </InputField>
       <InputField
-        id="literatureReferenceDocumentType"
         v-if="reference.referenceType === 'literature'"
+        id="literatureReferenceDocumentType"
         label="Dokumenttyp *"
       >
         <ComboboxInput
           id="literatureReferenceDocumentType"
           v-model="reference.documentType"
           aria-label="Dokumenttyp Literaturfundstelle"
-          :item-service="ComboboxItemService.getDocumentTypes"
+          :item-service="
+            ComboboxItemService.getDependentLiteratureDocumentTypes
+          "
         ></ComboboxInput>
       </InputField>
     </div>
     <InputField
-      id="literatureReferenceDocumentType"
       v-if="reference.referenceType === 'literature'"
+      id="literatureReferenceDocumentType"
       label="Autor *"
     >
       <TextInput

--- a/frontend/src/domain/reference.ts
+++ b/frontend/src/domain/reference.ts
@@ -1,7 +1,7 @@
+import { DocumentType } from "./documentUnit"
 import EditableListItem from "./editableListItem"
 import RelatedDocumentation from "./relatedDocumentation"
 import LegalPeriodical from "@/domain/legalPeriodical"
-import { DocumentType } from "./documentUnit"
 
 export default class Reference implements EditableListItem {
   id?: string

--- a/frontend/src/domain/reference.ts
+++ b/frontend/src/domain/reference.ts
@@ -1,6 +1,7 @@
 import EditableListItem from "./editableListItem"
 import RelatedDocumentation from "./relatedDocumentation"
 import LegalPeriodical from "@/domain/legalPeriodical"
+import { DocumentType } from "./documentUnit"
 
 export default class Reference implements EditableListItem {
   id?: string
@@ -10,6 +11,9 @@ export default class Reference implements EditableListItem {
   legalPeriodical?: LegalPeriodical
   legalPeriodicalRawValue?: string
   documentationUnit?: RelatedDocumentation
+  documentType?: DocumentType
+  author?: string
+  referenceType: "caselaw" | "literature" = "caselaw"
 
   static readonly requiredFields = [
     "legalPeriodical",

--- a/frontend/src/services/comboboxItemService.ts
+++ b/frontend/src/services/comboboxItemService.ts
@@ -13,6 +13,7 @@ import errorMessages from "@/i18n/errors.json"
 
 enum Endpoint {
   documentTypes = "documenttypes",
+  dependentLiteratureDocumentTypes = "documenttypes/dependent-literature",
   courts = "courts",
   citationTypes = "citationtypes",
   fieldOfLawSearchByIdentifier = "fieldsoflaw/search-by-identifier",
@@ -29,7 +30,8 @@ function formatDropdownItems(
   endpoint: Endpoint,
 ): ComboboxItem[] {
   switch (endpoint) {
-    case Endpoint.documentTypes: {
+    case Endpoint.documentTypes:
+    case Endpoint.dependentLiteratureDocumentTypes: {
       return (responseData as DocumentType[]).map((item) => ({
         label: item.label,
         value: item,
@@ -153,6 +155,8 @@ const service: ComboboxItemService = {
     await fetchFromEndpoint(Endpoint.courts, filter),
   getDocumentTypes: async (filter?: string) =>
     await fetchFromEndpoint(Endpoint.documentTypes, filter),
+  getDependentLiteratureDocumentTypes: async (filter?: string) =>
+    await fetchFromEndpoint(Endpoint.dependentLiteratureDocumentTypes, filter),
   getFieldOfLawSearchByIdentifier: async (filter?: string) =>
     await fetchFromEndpoint(Endpoint.fieldOfLawSearchByIdentifier, filter),
   getRisAbbreviations: async (filter?: string) =>

--- a/frontend/test/components/periodicalEvaluation/editionReferences.spec.ts
+++ b/frontend/test/components/periodicalEvaluation/editionReferences.spec.ts
@@ -137,6 +137,8 @@ describe("Legal periodical edition evaluation", () => {
 
   test("renders legal periodical reference input", async () => {
     await renderComponent()
+    expect(screen.getByLabelText("Rechtsprechung Fundstelle")).toBeChecked()
+    expect(screen.getByLabelText("Literatur Fundstelle")).not.toBeChecked()
     expect(
       screen.getByLabelText("Zitatstelle Präfix", { exact: true }),
     ).toHaveValue("präfix")
@@ -162,6 +164,34 @@ describe("Legal periodical edition evaluation", () => {
     expect(
       screen.getByLabelText("Klammernzusatz", { exact: true }),
     ).toBeInTheDocument()
+  })
+
+  test("toggles input fields, when changing reference type", async () => {
+    const { user } = await renderComponent()
+
+    expect(screen.getByLabelText("Rechtsprechung Fundstelle")).toBeChecked()
+    expect(screen.getByLabelText("Literatur Fundstelle")).not.toBeChecked()
+    expect(
+      screen.getByLabelText("Klammernzusatz", { exact: true }),
+    ).toBeVisible()
+    expect(
+      screen.queryByLabelText("Dokumenttyp Literaturfundstelle"),
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByLabelText("Autor Literaturfundstelle"),
+    ).not.toBeInTheDocument()
+
+    await user.click(screen.getByLabelText("Literatur Fundstelle"))
+
+    expect(screen.getByLabelText("Rechtsprechung Fundstelle")).not.toBeChecked()
+    expect(screen.getByLabelText("Literatur Fundstelle")).toBeChecked()
+    expect(
+      screen.queryByLabelText("Klammernzusatz", { exact: true }),
+    ).not.toBeInTheDocument()
+    expect(
+      screen.getByLabelText("Dokumenttyp Literaturfundstelle"),
+    ).toBeVisible()
+    expect(screen.getByLabelText("Autor Literaturfundstelle")).toBeVisible()
   })
 
   test("deletes documentation unit created by reference when selected", async () => {

--- a/frontend/test/e2e/caselaw/categories/references.spec.ts
+++ b/frontend/test/e2e/caselaw/categories/references.spec.ts
@@ -289,6 +289,18 @@ test.describe(
           ).toBeVisible()
           await expect(page.getByLabel("Klammernzusatz")).toBeHidden()
         })
+
+        // await test.step("Save literature reference", async () => {
+
+        // })
+
+        // await test.step("Literature reference visible in correct order", async () => {
+
+        // })
+
+        // await test.step("Radio buttons should not be visible after saving", async () => {
+
+        // })
       },
     )
 

--- a/frontend/test/e2e/caselaw/categories/references.spec.ts
+++ b/frontend/test/e2e/caselaw/categories/references.spec.ts
@@ -280,8 +280,6 @@ test.describe(
 
           await expect(page.getByLabel("Literatur Fundstelle")).toBeChecked()
 
-          await expect(page.getByLabel("Klammernzusatz")).toBeHidden()
-
           await expect(
             page.getByLabel("Dokumenttyp Literaturfundstelle"),
           ).toBeVisible()
@@ -289,6 +287,7 @@ test.describe(
           await expect(
             page.getByLabel("Autor Literaturfundstelle"),
           ).toBeVisible()
+          await expect(page.getByLabel("Klammernzusatz")).toBeHidden()
         })
       },
     )

--- a/frontend/test/e2e/caselaw/categories/references.spec.ts
+++ b/frontend/test/e2e/caselaw/categories/references.spec.ts
@@ -245,6 +245,55 @@ test.describe(
     )
 
     test(
+      "Literature references can be added to documentation unit",
+      {
+        tag: "@RISDEV-5236",
+      },
+      async ({ page, documentNumber }) => {
+        await test.step("Caselaw reference type is preselected", async () => {
+          await navigateToReferences(page, documentNumber)
+
+          await expect(
+            page.getByLabel("Rechtsprechung Fundstelle"),
+          ).toBeChecked()
+
+          await expect(
+            page.getByLabel("Literatur Fundstelle"),
+          ).not.toBeChecked()
+
+          await expect(page.getByLabel("Klammernzusatz")).toBeVisible()
+
+          await expect(
+            page.getByLabel("Dokumenttyp Literaturfundstelle"),
+          ).toBeHidden()
+
+          await expect(
+            page.getByLabel("Autor Literaturfundstelle"),
+          ).toBeHidden()
+        })
+
+        await test.step("Selecting literature reference type, renders different inputs", async () => {
+          await page.getByLabel("Literatur Fundstelle").click()
+          await expect(
+            page.getByLabel("Rechtsprechung Fundstelle"),
+          ).not.toBeChecked()
+
+          await expect(page.getByLabel("Literatur Fundstelle")).toBeChecked()
+
+          await expect(page.getByLabel("Klammernzusatz")).toBeHidden()
+
+          await expect(
+            page.getByLabel("Dokumenttyp Literaturfundstelle"),
+          ).toBeVisible()
+
+          await expect(
+            page.getByLabel("Autor Literaturfundstelle"),
+          ).toBeVisible()
+        })
+      },
+    )
+
+    test(
       "References are visible in preview",
       {
         annotation: {

--- a/frontend/test/e2e/caselaw/legal-periodical-evaluation.spec.ts
+++ b/frontend/test/e2e/caselaw/legal-periodical-evaluation.spec.ts
@@ -575,6 +575,18 @@ test.describe(
             page.getByLabel("Autor Literaturfundstelle"),
           ).toBeVisible()
         })
+
+        // await test.step("Save literature reference", async () => {
+
+        // })
+
+        // await test.step("Literature reference correctly sorted with other references", async () => {
+
+        // })
+
+        // await test.step("Radio buttons should not be visible after saving", async () => {
+
+        // })
       },
     )
 

--- a/frontend/test/e2e/caselaw/legal-periodical-evaluation.spec.ts
+++ b/frontend/test/e2e/caselaw/legal-periodical-evaluation.spec.ts
@@ -526,6 +526,58 @@ test.describe(
       },
     )
 
+    test(
+      "Literature references can be added to periodical evaluation",
+      {
+        tag: "@RISDEV-5236",
+      },
+      async ({ page, editionWithReferences }) => {
+        await test.step("Caselaw reference type is preselected", async () => {
+          await navigateToPeriodicalReferences(
+            page,
+            editionWithReferences.id || "",
+          )
+
+          await expect(
+            page.getByLabel("Rechtsprechung Fundstelle"),
+          ).toBeChecked()
+
+          await expect(
+            page.getByLabel("Literatur Fundstelle"),
+          ).not.toBeChecked()
+
+          await expect(page.getByLabel("Klammernzusatz")).toBeVisible()
+
+          await expect(
+            page.getByLabel("Dokumenttyp Literaturfundstelle"),
+          ).toBeHidden()
+
+          await expect(
+            page.getByLabel("Autor Literaturfundstelle"),
+          ).toBeHidden()
+        })
+
+        await test.step("Selecting literature reference type, renders different inputs", async () => {
+          await page.getByLabel("Literatur Fundstelle").click()
+          await expect(
+            page.getByLabel("Rechtsprechung Fundstelle"),
+          ).not.toBeChecked()
+
+          await expect(page.getByLabel("Literatur Fundstelle")).toBeChecked()
+
+          await expect(page.getByLabel("Klammernzusatz")).toBeHidden()
+
+          await expect(
+            page.getByLabel("Dokumenttyp Literaturfundstelle"),
+          ).toBeVisible()
+
+          await expect(
+            page.getByLabel("Autor Literaturfundstelle"),
+          ).toBeVisible()
+        })
+      },
+    )
+
     // Flaky, needs some clarification
     // eslint-disable-next-line playwright/no-skipped-test
     test.skip(


### PR DESCRIPTION
- new document type controller endpoint to get all document types with category "U"
- added radio buttons for conditional rendering of literature or caselaw reference inputs
- both for periodical evaluation reference input and documentation unit reference input