### PR TITLE
Improve search query performance

### DIFF
--- a/backend/src/main/java/de/bund/digitalservice/ris/caselaw/adapter/database/jpa/DatabaseDocumentationUnitRepository.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/caselaw/adapter/database/jpa/DatabaseDocumentationUnitRepository.java
@@ -51,16 +51,9 @@ public interface DatabaseDocumentationUnitRepository
     )
    AND (:withErrorOnly = FALSE OR documentationUnit.documentationOffice.id = :documentationOfficeId AND documentationUnit.status.withError = TRUE)
    ORDER BY
-     CASE
-       WHEN (:scheduledOnly = TRUE OR CAST(:publicationDate AS DATE) IS NOT NULL)
-          AND documentationUnit.scheduledPublicationDateTime IS NOT NULL
-          THEN documentationUnit.scheduledPublicationDateTime
-       WHEN (:scheduledOnly = TRUE OR CAST(:publicationDate AS DATE) IS NOT NULL)
-          AND documentationUnit.scheduledPublicationDateTime IS NULL
-          AND CAST(documentationUnit.lastPublicationDateTime as date) = :publicationDate
-          THEN documentationUnit.lastPublicationDateTime
-       ELSE documentationUnit.decisionDate
-     END DESC NULLS LAST
+     (CASE WHEN (:scheduledOnly = TRUE OR CAST(:publicationDate AS DATE) IS NOT NULL) THEN documentationUnit.scheduledPublicationDateTime END) DESC NULLS LAST,
+     (CASE WHEN (:scheduledOnly = TRUE OR CAST(:publicationDate AS DATE) IS NOT NULL) THEN documentationUnit.lastPublicationDateTime END) DESC NULLS LAST,
+     documentationUnit.decisionDate DESC NULLS LAST
 """;
 
   @Query(

--- a/backend/src/test/java/de/bund/digitalservice/ris/caselaw/integration/tests/DocumentationUnitSearchIntegrationTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/caselaw/integration/tests/DocumentationUnitSearchIntegrationTest.java
@@ -318,7 +318,7 @@ class DocumentationUnitSearchIntegrationTest {
             null,
             LocalDateTime.of(2022, 1, 23, 9, 5),
             LocalDateTime.of(2022, 1, 23, 19, 5),
-            LocalDateTime.of(2024, 1, 23, 8, 5),
+            LocalDateTime.of(2022, 1, 23, 8, 5),
             LocalDateTime.of(2022, 1, 24, 10, 5),
             null);
 
@@ -359,32 +359,34 @@ class DocumentationUnitSearchIntegrationTest {
             .getResponseBody();
 
     /*
+     * These are unlikely test conditions, because scheduled dates are in the future only and lastPublication dates in the past only.
+     *
      * Ordered results visible for user (lastPublicationDate only if scheduledPublicationDate is null):
-     * 2022-01-23 19:05
      * 2022-01-23 12:10
      * 2022-01-23 10:10
+     * 2022-01-23 05:03
+     * 2022-01-23 19:05
      * 2022-01-23 10:05
      * 2022-01-23 09:05
-     * 2022-01-23 05:03
      */
     assertThat(responseBody)
         .extracting("scheduledPublicationDateTime")
         .containsExactly(
-            null,
             LocalDateTime.of(2022, 1, 23, 12, 10),
             LocalDateTime.of(2022, 1, 23, 10, 10),
+            LocalDateTime.of(2022, 1, 23, 5, 3),
             null,
             null,
-            LocalDateTime.of(2022, 1, 23, 5, 3));
+            null);
     assertThat(responseBody)
         .extracting("lastPublicationDateTime")
         .containsExactly(
-            LocalDateTime.of(2022, 1, 23, 19, 5),
             null,
-            LocalDateTime.of(2024, 1, 23, 8, 5),
+            LocalDateTime.of(2022, 1, 23, 8, 5),
+            null,
+            LocalDateTime.of(2022, 1, 23, 19, 5),
             LocalDateTime.of(2022, 1, 23, 10, 5),
-            LocalDateTime.of(2022, 1, 23, 9, 5),
-            null);
+            LocalDateTime.of(2022, 1, 23, 9, 5));
   }
 
   @Test


### PR DESCRIPTION
RISDEV-5446
For the query optimizer to be able to use the index, we cannot use dynamic conditions in the CASE WHEN statements in the order by statement.

With this change, the index is used for queries that do not relate to Terminierte Abgabe.