### PR TITLE
Improve search query performance

### DIFF
--- a/backend/src/main/java/de/bund/digitalservice/ris/caselaw/adapter/database/jpa/DocumentationUnitDTO.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/caselaw/adapter/database/jpa/DocumentationUnitDTO.java
@@ -292,25 +292,25 @@ public class DocumentationUnitDTO implements DocumentationUnitListItemDTO {
   @OrderBy("rank")
   private List<ReferenceDTO> references = new ArrayList<>();
 
-  @OneToMany(cascade = CascadeType.ALL, fetch = FetchType.EAGER, orphanRemoval = true)
+  @OneToMany(cascade = CascadeType.ALL, fetch = FetchType.LAZY, orphanRemoval = true)
   @JoinColumn(name = "documentation_unit_id", nullable = false)
   @OrderBy("rank")
   @Builder.Default
   private List<JobProfileDTO> jobProfiles = new ArrayList<>();
 
-  @OneToMany(cascade = CascadeType.ALL, fetch = FetchType.EAGER, orphanRemoval = true)
+  @OneToMany(cascade = CascadeType.ALL, fetch = FetchType.LAZY, orphanRemoval = true)
   @JoinColumn(name = "documentation_unit_id", nullable = false)
   @OrderBy("rank")
   @Builder.Default
   private List<DismissalGroundsDTO> dismissalGrounds = new ArrayList<>();
 
-  @OneToMany(cascade = CascadeType.ALL, fetch = FetchType.EAGER, orphanRemoval = true)
+  @OneToMany(cascade = CascadeType.ALL, fetch = FetchType.LAZY, orphanRemoval = true)
   @JoinColumn(name = "documentation_unit_id", nullable = false)
   @OrderBy("rank")
   @Builder.Default
   private List<DismissalTypesDTO> dismissalTypes = new ArrayList<>();
 
-  @OneToMany(cascade = CascadeType.ALL, fetch = FetchType.EAGER, orphanRemoval = true)
+  @OneToMany(cascade = CascadeType.ALL, fetch = FetchType.LAZY, orphanRemoval = true)
   @JoinColumn(name = "documentation_unit_id", nullable = false)
   @OrderBy("rank")
   @Builder.Default
@@ -319,7 +319,7 @@ public class DocumentationUnitDTO implements DocumentationUnitListItemDTO {
   @Column(name = "legislative_mandate")
   private boolean hasLegislativeMandate;
 
-  @OneToMany(cascade = CascadeType.ALL, fetch = FetchType.EAGER, orphanRemoval = true)
+  @OneToMany(cascade = CascadeType.ALL, fetch = FetchType.LAZY, orphanRemoval = true)
   @JoinColumn(name = "documentation_unit_id", nullable = false)
   @OrderBy("rank")
   @Builder.Default


### PR DESCRIPTION
RISDEV-0000
These additional categories are not relevant for the search results but are still fetched for each row (N+1 problem) because of the EAGER fetching. With lazy fetching, they will only be queried on demand (e.g. when loading the whole doc unit).