### PR TITLE
Cancel+debounce Combobox requests + delayed enter

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -95,6 +95,7 @@
         "jest-fail-on-console": "^3.3.1",
         "jsdom": "^25.0.1",
         "license-checker": "^25.0.1",
+        "msw": "^2.6.8",
         "playwright": "^1.49.0",
         "postcss": "^8.4.49",
         "postcss-import": "^16.1.0",
@@ -714,6 +715,63 @@
       "resolved": "https://registry.npmjs.org/@braintree/sanitize-url/-/sanitize-url-7.1.0.tgz",
       "integrity": "sha512-o+UlMLt49RvtCASlOMW0AkHnabN9wR9rwCCherxO0yG4Npy34GkvrAqdXQvrhNs+jh+gkK8gB8Lf05qL/O7KWg==",
       "license": "MIT"
+    },
+    "node_modules/@bundled-es-modules/cookie": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@bundled-es-modules/cookie/-/cookie-2.0.1.tgz",
+      "integrity": "sha512-8o+5fRPLNbjbdGRRmJj3h6Hh1AQJf2dk3qQ/5ZFb+PXkRNiSoMGGUKlsgLfrxneb72axVJyIYji64E2+nNfYyw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "cookie": "^0.7.2"
+      }
+    },
+    "node_modules/@bundled-es-modules/statuses": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@bundled-es-modules/statuses/-/statuses-1.0.1.tgz",
+      "integrity": "sha512-yn7BklA5acgcBr+7w064fGV+SGIFySjCKpqjcWgBAIfrAkY+4GQTJJHQMeT3V/sgz23VTEVV8TtOmkvJAhFVfg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "statuses": "^2.0.1"
+      }
+    },
+    "node_modules/@bundled-es-modules/tough-cookie": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@bundled-es-modules/tough-cookie/-/tough-cookie-0.1.6.tgz",
+      "integrity": "sha512-dvMHbL464C0zI+Yqxbz6kZ5TOEp7GLW+pry/RWndAR8MJQAXZ2rPmIs8tziTZjeIyhSNZgZbCePtfSbdWqStJw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@types/tough-cookie": "^4.0.5",
+        "tough-cookie": "^4.1.4"
+      }
+    },
+    "node_modules/@bundled-es-modules/tough-cookie/node_modules/tough-cookie": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.4.tgz",
+      "integrity": "sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "psl": "^1.1.33",
+        "punycode": "^2.1.1",
+        "universalify": "^0.2.0",
+        "url-parse": "^1.5.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@bundled-es-modules/tough-cookie/node_modules/universalify": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
+      "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
     },
     "node_modules/@csstools/css-parser-algorithms": {
       "version": "3.0.4",
@@ -1563,6 +1621,118 @@
         "url": "https://github.com/sponsors/antfu"
       }
     },
+    "node_modules/@inquirer/confirm": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-5.1.0.tgz",
+      "integrity": "sha512-osaBbIMEqVFjTX5exoqPXs6PilWQdjaLhGtMDXMXg/yxkHXNq43GlxGyTA35lK2HpzUgDN+Cjh/2AmqCN0QJpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.1.1",
+        "@inquirer/type": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/core": {
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.1.1.tgz",
+      "integrity": "sha512-rmZVXy9iZvO3ZStEe/ayuuwIJ23LSF13aPMlLMTQARX6lGUBDHGV8UB5i9MRrfy0+mZwt5/9bdy8llszSD3NQA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/figures": "^1.0.8",
+        "@inquirer/type": "^3.0.1",
+        "ansi-escapes": "^4.3.2",
+        "cli-width": "^4.1.0",
+        "mute-stream": "^2.0.0",
+        "signal-exit": "^4.1.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^6.2.0",
+        "yoctocolors-cjs": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/core/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@inquirer/core/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/@inquirer/core/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@inquirer/core/node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@inquirer/figures": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.8.tgz",
+      "integrity": "sha512-tKd+jsmhq21AP1LhexC0pPwsCxEhGgAkg28byjJAd+xhmIs8LUX8JbUc3vBf3PhLxWiB5EvyBE5X7JSPAqMAqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/type": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.1.tgz",
+      "integrity": "sha512-+ksJMIy92sOAiAccGpcKZUc3bYO07cADnscIxHBknEm3uNts3movSmBofc1908BNy5edKscxYeAdaX1NXkHS6A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      }
+    },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
@@ -1697,6 +1867,24 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@mswjs/interceptors": {
+      "version": "0.37.3",
+      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.37.3.tgz",
+      "integrity": "sha512-USvgCL/uOGFtVa6SVyRrC8kIAedzRohxIXN5LISlg5C5vLZCn7dgMFVSNhSF9cuBEFrm/O2spDWEZeMnw4ZXYg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@open-draft/deferred-promise": "^2.2.0",
+        "@open-draft/logger": "^0.3.0",
+        "@open-draft/until": "^2.0.0",
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.3",
+        "strict-event-emitter": "^0.5.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@namics/stylelint-bem": {
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/@namics/stylelint-bem/-/stylelint-bem-10.1.0.tgz",
@@ -1766,6 +1954,31 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/@one-ini/wasm/-/wasm-0.1.1.tgz",
       "integrity": "sha512-XuySG1E38YScSJoMlqovLru4KTUNSjgVTIjyh7qMX6aNN5HY5Ct5LhRJdxO79JtTzKfzV/bnWpz+zquYrISsvw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@open-draft/deferred-promise": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/deferred-promise/-/deferred-promise-2.2.0.tgz",
+      "integrity": "sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@open-draft/logger": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/logger/-/logger-0.3.0.tgz",
+      "integrity": "sha512-X2g45fzhxH238HKO4xbSr7+wBS8Fvw6ixhTDuvLd5mqh6bJJCFAPwU9mPDxbcrRtfxv4u5IHCEH77BmxvXmmxQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.0"
+      }
+    },
+    "node_modules/@open-draft/until": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/until/-/until-2.1.0.tgz",
+      "integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
       "dev": true,
       "license": "MIT"
     },
@@ -3593,6 +3806,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/cookie": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz",
+      "integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/debug": {
       "version": "4.1.12",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
@@ -3659,6 +3879,13 @@
       "dependencies": {
         "undici-types": "~6.20.0"
       }
+    },
+    "node_modules/@types/statuses": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@types/statuses/-/statuses-2.0.5.tgz",
+      "integrity": "sha512-jmIUGWrAiwu3dZpxntxieC+1n/5c3mjrImkmOSQ2NC5uP6cYO4aAZDdSmRcI5C1oiTmqlZGHC+/NmJrKogbP5A==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/tough-cookie": {
       "version": "4.0.5",
@@ -4628,6 +4855,35 @@
       "integrity": "sha512-StlonZhBBrsPPwrDjiPAiVTf/rolxffLxVPT60Qv/t88BZ81BvUVzHgGqEFvJ1ii8HXtm1+zU2Icr59tfWEcag==",
       "license": "MIT"
     },
+    "node_modules/ansi-escapes": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
+      "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^0.21.3"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ansi-escapes/node_modules/type-fest": {
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
@@ -5261,6 +5517,85 @@
         "node": ">= 6"
       }
     },
+    "node_modules/cli-width": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
+      "integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/cliui/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/cliui/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/cliui/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cliui/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "node_modules/color-convert": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
@@ -5338,6 +5673,16 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/copy-anything": {
       "version": "3.0.5",
@@ -7438,6 +7783,16 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
     "node_modules/get-intrinsic": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.4.tgz",
@@ -7680,6 +8035,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/graphql": {
+      "version": "16.9.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.9.0.tgz",
+      "integrity": "sha512-GGTKBX4SD7Wdb8mqeDLni2oaRGYQWjWHGKPQ24ZMnUtKfcsVoiv4uX8+LJr1K6U5VW2Lu1BwJnj7uiori0YtRw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
+      }
+    },
     "node_modules/has-bigints": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
@@ -7776,6 +8141,13 @@
       "bin": {
         "he": "bin/he"
       }
+    },
+    "node_modules/headers-polyfill": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/headers-polyfill/-/headers-polyfill-4.0.3.tgz",
+      "integrity": "sha512-IScLbePpkvO846sIwOtOTDjutRMWdXdJmXdMvk6gCBHxFO8d+QKOQedyZSxFTTFYRSmlgSTDtXqqq4pcenBXLQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/hookable": {
       "version": "5.5.3",
@@ -8304,6 +8676,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/is-node-process": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-node-process/-/is-node-process-1.2.0.tgz",
+      "integrity": "sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/is-number": {
       "version": "7.0.0",
@@ -9439,6 +9818,140 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/msw": {
+      "version": "2.6.8",
+      "resolved": "https://registry.npmjs.org/msw/-/msw-2.6.8.tgz",
+      "integrity": "sha512-nxXxnH6WALZ9a7rsQp4HU2AaD4iGAiouMmE/MY4al7pXTibgA6OZOuKhmN2WBIM6w9qMKwRtX8p2iOb45B2M/Q==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bundled-es-modules/cookie": "^2.0.1",
+        "@bundled-es-modules/statuses": "^1.0.1",
+        "@bundled-es-modules/tough-cookie": "^0.1.6",
+        "@inquirer/confirm": "^5.0.0",
+        "@mswjs/interceptors": "^0.37.0",
+        "@open-draft/deferred-promise": "^2.2.0",
+        "@open-draft/until": "^2.1.0",
+        "@types/cookie": "^0.6.0",
+        "@types/statuses": "^2.0.4",
+        "chalk": "^4.1.2",
+        "graphql": "^16.8.1",
+        "headers-polyfill": "^4.0.2",
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.3",
+        "path-to-regexp": "^6.3.0",
+        "strict-event-emitter": "^0.5.1",
+        "type-fest": "^4.26.1",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "msw": "cli/index.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mswjs"
+      },
+      "peerDependencies": {
+        "typescript": ">= 4.8.x"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/msw/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/msw/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/msw/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/msw/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/msw/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/msw/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/msw/node_modules/type-fest": {
+      "version": "4.30.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.30.0.tgz",
+      "integrity": "sha512-G6zXWS1dLj6eagy6sVhOMQiLtJdxQBHIA9Z6HFUNLOlr6MFOgzV8wvmidtPONfPtEUv0uZsy77XJNzTAfwPDaA==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/muggle-string": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/muggle-string/-/muggle-string-0.4.1.tgz",
@@ -9453,6 +9966,16 @@
       "license": "MIT",
       "bin": {
         "mustache": "bin/mustache"
+      }
+    },
+    "node_modules/mute-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-2.0.0.tgz",
+      "integrity": "sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/mz": {
@@ -9886,6 +10409,13 @@
         "os-tmpdir": "^1.0.0"
       }
     },
+    "node_modules/outvariant": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/outvariant/-/outvariant-1.4.3.tgz",
+      "integrity": "sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/p-limit": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -10076,6 +10606,13 @@
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/path-type": {
       "version": "4.0.0",
@@ -10912,6 +11449,19 @@
       "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
       "license": "MIT"
     },
+    "node_modules/psl": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
+      "integrity": "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/lupomontero"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -10931,6 +11481,13 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
@@ -11126,6 +11683,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/require-from-string": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
@@ -11145,6 +11712,13 @@
       "engines": {
         "node": ">=0.10.5"
       }
+    },
+    "node_modules/requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/resize-observer-polyfill": {
       "version": "1.5.1",
@@ -11714,6 +12288,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/statuses": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/std-env": {
       "version": "3.8.0",
       "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.8.0.tgz",
@@ -11733,6 +12317,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/strict-event-emitter": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.5.1.tgz",
+      "integrity": "sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/string-width": {
       "version": "4.2.3",
@@ -13265,6 +13856,17 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/url-parse": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
       }
     },
     "node_modules/util-deprecate": {
@@ -15208,6 +15810,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/yallist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
@@ -15228,6 +15840,35 @@
         "node": ">= 14"
       }
     },
+    "node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
@@ -15245,6 +15886,19 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.1.1.tgz",
       "integrity": "sha512-GQHQqAopRhwU8Kt1DDM8NjibDXHC8eoh1erhGAJPEyveY9qqVeXvVikNKrDz69sHowPMorbPUrH/mx8c50eiBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/yoctocolors-cjs": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yoctocolors-cjs/-/yoctocolors-cjs-2.1.2.tgz",
+      "integrity": "sha512-cYVsTjKl8b+FrnidjibDWskAv7UKOfcwaVZdp/it9n1s9fU3IkgDbhdIRKCW4JDsAlECJY0ytoVPT3sK6kideA==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -121,6 +121,7 @@
     "jest-fail-on-console": "^3.3.1",
     "jsdom": "^25.0.1",
     "license-checker": "^25.0.1",
+    "msw": "^2.6.8",
     "playwright": "^1.49.0",
     "postcss": "^8.4.49",
     "postcss-import": "^16.1.0",

--- a/frontend/src/components/ComboboxInput.vue
+++ b/frontend/src/components/ComboboxInput.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts" generic="T extends InputModelProps">
-import * as Sentry from "@sentry/vue"
+import { useDebounceFn } from "@vueuse/core"
 import {
   computed,
   onBeforeUnmount,
@@ -42,8 +42,7 @@ const NO_MATCHING_ENTRY = "Kein passender Eintrag"
 
 const candidateForSelection = ref<ComboboxItem>() // <-- the top search result
 const inputText = ref<string>()
-const existingItems = ref<ComboboxItem[]>()
-const currentlyDisplayedItems = computed(() =>
+const currentlyDisplayedItems = computed<ComboboxItem[]>(() =>
   [...(existingItems.value ?? []), createNewItem.value].filter(isDefined),
 )
 const createNewItem = ref<ComboboxItem>()
@@ -54,14 +53,8 @@ const dropdownItemsRef = shallowRef<HTMLElement[]>([])
 const inputFieldRef = ref<HTMLInputElement>()
 const focusedItemIndex = ref<number>(-1)
 
-const isUpdating = ref(false)
-const hasToUpdate = ref(false)
-
 const ariaLabelDropdownIcon = computed(() =>
   showDropdown.value ? "Dropdown schließen" : "Dropdown öffnen",
-)
-const noMatchingExistingItems = computed(
-  () => !existingItems.value || existingItems.value.length === 0,
 )
 
 const conditionalClasses = computed(() => ({
@@ -113,12 +106,19 @@ const setChosenItem = (item: ComboboxItem) => {
   candidateForSelection.value = undefined
 }
 
+/** When user hits enter while fetching -> wait for results before executing enter action */
+const hasQueuedEnter = ref(false)
 const onEnter = async () => {
-  if (candidateForSelection.value) {
-    setChosenItem(candidateForSelection.value)
-    return
+  if (isFetchingOrTyping.value) {
+    hasQueuedEnter.value = true
+  } else {
+    hasQueuedEnter.value = false
+    if (candidateForSelection.value) {
+      setChosenItem(candidateForSelection.value)
+      return
+    }
+    await toggleDropdown()
   }
-  await toggleDropdown()
 }
 
 const onInput = async () => {
@@ -149,65 +149,63 @@ const updateFocusedItem = () => {
   if (item && item.innerText !== NO_MATCHING_ENTRY) item.focus()
 }
 
-const updateCurrentItems = async () => {
-  hasToUpdate.value = true
-  if (isUpdating.value && hasToUpdate.value) {
-    return
+const isFetchingOrTyping = ref(false)
+
+async function updateCurrentItems() {
+  isFetchingOrTyping.value = true
+  if (canAbort.value) {
+    abort()
   }
-
-  isUpdating.value = true
-
-  let response
-  let tries = 0
-  do {
-    hasToUpdate.value = false
-    response = await props.itemService(filter.value)
-    isUpdating.value = false
-    tries++
-  } while (hasToUpdate.value && tries < 6)
-
-  if (tries >= 6) {
-    Sentry.captureMessage(
-      "more than 5 tries to call the item service at the combobox",
-      "error",
-    )
-  }
-
-  if (!response.data) {
-    console.error(response.error)
-    return
-  }
-
-  existingItems.value = response.data
-
-  if (
-    noMatchingExistingItems.value ||
-    //no exact match found when add manual entry option set
-    (props.manualEntry &&
-      filter.value &&
-      !existingItems.value.find((item) => item.label === filter.value?.trim()))
-  ) {
-    handleNoSearchResults(filter.value)
-  } else {
-    createNewItem.value = undefined
-    candidateForSelection.value = existingItems.value[0]
-    focusedItemIndex.value = 0
-  }
+  const response = await debouncedFetchItems()
+  if (response) isFetchingOrTyping.value = false
 }
 
-function handleNoSearchResults(searchStr?: string) {
-  if (props.manualEntry && searchStr) {
+watch(isFetchingOrTyping, async (isFetching, wasFetching) => {
+  if (wasFetching === true && isFetching === false) {
+    if (hasQueuedEnter.value) {
+      hasQueuedEnter.value = false
+      await onEnter()
+    }
+  }
+})
+
+const {
+  data: existingItems,
+  execute: fetchItems,
+  canAbort,
+  abort,
+} = props.itemService(filter)
+const debouncedFetchItems = useDebounceFn(fetchItems, 200)
+
+const noMatchingItems = [{ label: NO_MATCHING_ENTRY }]
+watch(existingItems, () => {
+  if (existingItems.value === null) return
+  if (existingItems.value === noMatchingItems) return
+
+  const noMatchesFound = !existingItems.value.length
+  const hasManualEntry = props.manualEntry && inputText.value
+  if (!hasManualEntry && noMatchesFound) {
+    existingItems.value = noMatchingItems
+    candidateForSelection.value = undefined
+    return
+  }
+
+  const exactMatchFound = existingItems.value?.find(
+    (item) => item.label === filter.value?.trim(),
+  )
+  if (!exactMatchFound && hasManualEntry) {
     createNewItem.value = {
-      label: `${searchStr} neu erstellen`,
-      value: { label: searchStr },
+      label: `${inputText.value} neu erstellen`,
+      value: { label: inputText.value! },
       labelCssClasses: "ds-label-01-bold text-blue-800 underline",
     }
-    candidateForSelection.value = { label: searchStr }
   } else {
-    existingItems.value = [{ label: NO_MATCHING_ENTRY }]
-    candidateForSelection.value = undefined
+    createNewItem.value = undefined
   }
-}
+
+  candidateForSelection.value = existingItems.value?.[0] ?? createNewItem.value
+  focusedItemIndex.value = 0
+})
 
 const handleClickOutside = (event: MouseEvent) => {
   const dropdown = dropdownContainerRef.value
@@ -306,14 +304,17 @@ export type InputModelProps =
       tabindex="-1"
     >
       <button
-        v-for="(item, index) in currentlyDisplayedItems"
-        :key="index"
+        v-for="item in currentlyDisplayedItems"
+        :key="item.label + item.additionalInformation"
         ref="dropdownItemsRef"
         aria-label="dropdown-option"
         class="cursor-pointer px-16 py-12 text-left hover:bg-blue-100 focus:border-l-4 focus:border-solid focus:border-l-blue-800 focus:bg-blue-200 focus:outline-none"
         :class="{
           'border-l-4 border-solid border-l-blue-800 bg-blue-200':
-            candidateForSelection === item,
+            candidateForSelection &&
+            candidateForSelection.label === item.label &&
+            candidateForSelection.additionalInformation ===
+              item.additionalInformation,
         }"
         tabindex="0"
         @click="setChosenItem(item)"

--- a/frontend/src/components/DocumentUnitSearch.vue
+++ b/frontend/src/components/DocumentUnitSearch.vue
@@ -14,7 +14,7 @@ import { Query } from "@/composables/useQueryFromRoute"
 import { Court } from "@/domain/documentUnit"
 import DocumentUnitListEntry from "@/domain/documentUnitListEntry"
 import errorMessages from "@/i18n/errors.json"
-import ComboboxItemService from "@/services/comboboxItemService"
+import comboboxItemService from "@/services/comboboxItemService"
 import service from "@/services/documentUnitService"
 import { ResponseError } from "@/services/httpClient"
 import { useDocumentUnitStore } from "@/stores/documentUnitStore"
@@ -44,6 +44,10 @@ const emptyStateLabel = computed(() => {
   }
   return undefined
 })
+
+const courtFilter = ref("")
+const { data: courts, execute: fetchCourts } =
+  comboboxItemService.getCourts(courtFilter)
 
 /**
  * Searches all documentation units by given input and updates the local
@@ -75,18 +79,19 @@ async function search() {
     !hasFilters.value &&
     searchQuery.value?.courtType
   ) {
-    const courtFilter =
+    courtFilter.value =
       searchQuery.value.courtType +
       (searchQuery.value.courtLocation
         ? ` ${searchQuery.value.courtLocation}`
         : "")
 
-    const courtResponse = (await ComboboxItemService.getCourts(courtFilter))
-      .data
+    await fetchCourts()
+
+    const courtResponse = courts.value
 
     //filter for exact matches
     const matches = courtResponse
-      ? courtResponse.filter((item) => item.label === courtFilter)
+      ? courtResponse.filter((item) => item.label === courtFilter.value)
       : []
 
     // add as court query only if 1 exact match

--- a/frontend/src/components/input/types.ts
+++ b/frontend/src/components/input/types.ts
@@ -1,3 +1,5 @@
+import { UseFetchReturn } from "@vueuse/core"
+import { Ref } from "vue"
 import { LabelPosition } from "@/components/input/InputField.vue"
 import { CitationType } from "@/domain/citationType"
 import DocumentationOffice from "@/domain/documentationOffice"
@@ -6,7 +8,6 @@ import { FieldOfLaw } from "@/domain/fieldOfLaw"
 import { LegalForceRegion, LegalForceType } from "@/domain/legalForce"
 import LegalPeriodical from "@/domain/legalPeriodical"
 import { NormAbbreviation } from "@/domain/normAbbreviation"
-import { ResponseError } from "@/services/httpClient"
 
 export enum InputType {
   TEXT = "text",
@@ -144,11 +145,9 @@ export type ComboboxItem = {
 }
 
 export interface ComboboxAttributes extends BaseInputAttributes {
-  itemService: (filter?: string) => Promise<{
-    status: number
-    data?: ComboboxItem[]
-    error?: ResponseError
-  }>
+  itemService: (
+    filter: Ref<string | undefined>,
+  ) => UseFetchReturn<ComboboxItem[]>
   placeholder?: string
   manualEntry?: boolean
   noClear?: boolean

--- a/frontend/test/components/comboboxInput.spec.ts
+++ b/frontend/test/components/comboboxInput.spec.ts
@@ -59,6 +59,8 @@ function renderComponent(
   }
 }
 
+const debounceTimeout = 200
+
 describe("Combobox Element", () => {
   beforeAll(() => server.listen())
   afterAll(() => server.close())
@@ -83,7 +85,7 @@ describe("Combobox Element", () => {
 
     const openComboboxContainer = screen.getByLabelText("Dropdown öffnen")
     await user.click(openComboboxContainer)
-    await vi.advanceTimersByTimeAsync(300)
+    await vi.advanceTimersByTimeAsync(debounceTimeout)
     expect(screen.getAllByLabelText("dropdown-option")).toHaveLength(3)
     const input = screen.getByLabelText("test label")
     await fireEvent.focus(input)
@@ -92,27 +94,25 @@ describe("Combobox Element", () => {
   })
 
   it("focus should open dropdown", async () => {
-    vi.useFakeTimers()
     renderComponent()
     const input = screen.getByLabelText("test label")
     await fireEvent.focus(input)
-    await vi.advanceTimersByTimeAsync(300)
+    await vi.advanceTimersByTimeAsync(debounceTimeout)
 
     expect(screen.getAllByLabelText("dropdown-option")).toHaveLength(3)
   })
 
   it("enter should select top value", async () => {
-    vi.useFakeTimers()
     const { emitted } = renderComponent()
     const input = screen.getByLabelText("test label")
     await fireEvent.focus(input)
-    await vi.advanceTimersByTimeAsync(300)
+    await vi.advanceTimersByTimeAsync(debounceTimeout)
     expect(screen.getAllByLabelText("dropdown-option")).toHaveLength(3)
 
     input.focus()
     await user.keyboard("{enter}")
 
-    await vi.advanceTimersByTimeAsync(300)
+    await vi.advanceTimersByTimeAsync(debounceTimeout)
 
     expect(emitted()["update:modelValue"]).toEqual([
       [
@@ -130,7 +130,7 @@ describe("Combobox Element", () => {
     const input = screen.getByLabelText("test label")
 
     await user.type(input, "court")
-    await vi.advanceTimersByTimeAsync(300)
+    await vi.advanceTimersByTimeAsync(debounceTimeout)
     const dropdownItems = screen.getAllByLabelText("dropdown-option")
     await user.click(dropdownItems[1])
 
@@ -158,7 +158,7 @@ describe("Combobox Element", () => {
     const input = screen.getByLabelText("test label")
     await user.type(input, "courtlabel2")
 
-    await vi.advanceTimersByTimeAsync(300)
+    await vi.advanceTimersByTimeAsync(debounceTimeout)
     const dropdownItems = screen.queryAllByLabelText("dropdown-option")
     expect(dropdownItems).toHaveLength(1)
 
@@ -171,7 +171,7 @@ describe("Combobox Element", () => {
     const input = screen.getByLabelText("test label")
     await user.type(input, "courtlabel2")
 
-    await vi.advanceTimersByTimeAsync(300)
+    await vi.advanceTimersByTimeAsync(debounceTimeout)
     const dropdownItems = screen.getAllByLabelText("dropdown-option")
 
     expect(dropdownItems[0]).toHaveTextContent("courtlabel2")
@@ -182,7 +182,7 @@ describe("Combobox Element", () => {
 
     await user.click(openDropdownContainer)
 
-    await vi.advanceTimersByTimeAsync(300)
+    await vi.advanceTimersByTimeAsync(debounceTimeout)
     expect(screen.getAllByLabelText("dropdown-option")).toHaveLength(1)
   })
 
@@ -192,7 +192,7 @@ describe("Combobox Element", () => {
     const input = screen.getByLabelText("test label")
     await user.type(input, "courtlabel2")
 
-    await vi.advanceTimersByTimeAsync(300)
+    await vi.advanceTimersByTimeAsync(debounceTimeout)
     const dropdownItems = screen.getAllByLabelText("dropdown-option")
 
     expect(dropdownItems).toHaveLength(1)
@@ -222,7 +222,7 @@ describe("Combobox Element", () => {
     const openDropdownContainer = screen.getByLabelText("Dropdown öffnen")
 
     await user.click(openDropdownContainer)
-    await vi.advanceTimersByTimeAsync(300)
+    await vi.advanceTimersByTimeAsync(debounceTimeout)
     const dropdownItems = screen.getAllByLabelText("dropdown-option")
     expect(dropdownItems).toHaveLength(1)
     expect(dropdownItems[0]).toHaveTextContent("courtlabel1")
@@ -234,7 +234,7 @@ describe("Combobox Element", () => {
     const input = screen.getByLabelText("test label")
     await user.type(input, "courtlabel10")
 
-    await vi.advanceTimersByTimeAsync(300)
+    await vi.advanceTimersByTimeAsync(debounceTimeout)
     const dropdownItems = screen.getAllByLabelText("dropdown-option")
     expect(dropdownItems).toHaveLength(1)
     expect(dropdownItems[0]).toHaveTextContent("Kein passender Eintrag")
@@ -246,7 +246,7 @@ describe("Combobox Element", () => {
     const input = screen.getByLabelText("test label")
     await user.type(input, "courtlabel2")
 
-    await vi.advanceTimersByTimeAsync(300)
+    await vi.advanceTimersByTimeAsync(debounceTimeout)
     const dropdownItems = screen.getAllByLabelText("dropdown-option")
     expect(screen.getAllByLabelText("dropdown-option")).toHaveLength(1)
     expect(dropdownItems[0]).toHaveTextContent("courtlabel2")
@@ -281,13 +281,13 @@ describe("Combobox Element", () => {
 
     const openDropdownContainer = screen.getByLabelText("Dropdown öffnen")
     await user.click(openDropdownContainer)
-    await vi.advanceTimersByTimeAsync(300)
+    await vi.advanceTimersByTimeAsync(debounceTimeout)
 
     const dropdownItems = screen.getAllByLabelText("dropdown-option")
 
     expect(dropdownItems).toHaveLength(1)
     expect(dropdownItems[0]).toHaveTextContent("AO - Anordnung")
-    await vi.advanceTimersByTimeAsync(300)
+    await vi.advanceTimersByTimeAsync(debounceTimeout)
   })
 
   it("uses endpoint to fetch all Court items", async () => {
@@ -304,7 +304,7 @@ describe("Combobox Element", () => {
     const openDropdownContainer = screen.getByLabelText("Dropdown öffnen")
 
     await user.click(openDropdownContainer)
-    await vi.advanceTimersByTimeAsync(300)
+    await vi.advanceTimersByTimeAsync(debounceTimeout)
 
     const dropdownItemElements = screen.getAllByLabelText("dropdown-option")
 
@@ -329,7 +329,7 @@ describe("Combobox Element", () => {
 
     const input = screen.getByLabelText("test label")
     await user.type(input, "bgh")
-    await vi.advanceTimersByTimeAsync(300)
+    await vi.advanceTimersByTimeAsync(debounceTimeout)
 
     const dropdownItemElements = screen.getAllByLabelText("dropdown-option")
 
@@ -353,7 +353,7 @@ describe("Combobox Element", () => {
 
     const openDropdownContainer = screen.getByLabelText("Dropdown öffnen")
     await user.click(openDropdownContainer)
-    await vi.advanceTimersByTimeAsync(300)
+    await vi.advanceTimersByTimeAsync(debounceTimeout)
 
     const dropdownItemElements = screen.getAllByLabelText("dropdown-option")
     expect(dropdownItemElements).toHaveLength(1)
@@ -371,33 +371,33 @@ describe("Combobox Element", () => {
 
     const input = screen.getByLabelText("test label")
     await user.type(input, "xxxxxx")
-    await vi.advanceTimersByTimeAsync(300)
+    await vi.advanceTimersByTimeAsync(debounceTimeout)
 
     let dropdownItems = screen.getAllByLabelText("dropdown-option")
     expect(dropdownItems).toHaveLength(1)
     expect(dropdownItems[0]).toHaveTextContent("Kein passender Eintrag")
 
     await user.keyboard("{escape}")
-    await vi.advanceTimersByTimeAsync(300)
+    await vi.advanceTimersByTimeAsync(debounceTimeout)
 
     expect(screen.queryByLabelText("dropdown-option")).not.toBeInTheDocument()
     expect(input).toHaveValue("")
 
     await user.type(input, "courtlabel1")
-    await vi.advanceTimersByTimeAsync(300)
+    await vi.advanceTimersByTimeAsync(debounceTimeout)
     dropdownItems = screen.getAllByLabelText("dropdown-option")
 
     expect(dropdownItems).toHaveLength(1)
     expect(dropdownItems[0]).toHaveTextContent("courtlabel1")
 
     await user.keyboard("{enter}") // save the value
-    await vi.advanceTimersByTimeAsync(300)
+    await vi.advanceTimersByTimeAsync(debounceTimeout)
     expect(screen.queryByLabelText("dropdown-option")).not.toBeInTheDocument()
     expect(input).toHaveValue("courtlabel1")
 
     await user.type(input, "foo")
     await user.keyboard("{tab}")
-    await vi.advanceTimersByTimeAsync(300)
+    await vi.advanceTimersByTimeAsync(debounceTimeout)
 
     expect(screen.queryByLabelText("dropdown-option")).not.toBeInTheDocument()
     // expect(input).toHaveValue("testItem1") does not work here anymore because
@@ -410,7 +410,7 @@ describe("Combobox Element", () => {
     const { emitted } = renderComponent()
     const input = screen.getByLabelText("test label")
     await user.type(input, "court")
-    await vi.advanceTimersByTimeAsync(300)
+    await vi.advanceTimersByTimeAsync(debounceTimeout)
     expect(screen.getAllByLabelText("dropdown-option")).toHaveLength(3)
 
     await user.keyboard("{enter}")
@@ -435,7 +435,7 @@ describe("Combobox Element", () => {
     const input = screen.getByLabelText("test label")
     await user.type(input, "foo")
 
-    await vi.advanceTimersByTimeAsync(300)
+    await vi.advanceTimersByTimeAsync(debounceTimeout)
     const dropdownItems = screen.queryAllByLabelText("dropdown-option")
     expect(dropdownItems).toHaveLength(1)
     expect(dropdownItems[0]).toHaveTextContent("foo neu erstellen")
@@ -456,7 +456,7 @@ describe("Combobox Element", () => {
     const input = screen.getByLabelText("test label")
     await user.type(input, "court")
 
-    await vi.advanceTimersByTimeAsync(300)
+    await vi.advanceTimersByTimeAsync(debounceTimeout)
     const dropdownItems = screen.queryAllByLabelText("dropdown-option")
     expect(dropdownItems).toHaveLength(4)
     expect(dropdownItems[0]).toHaveTextContent("courtlabel1")
@@ -469,14 +469,14 @@ describe("Combobox Element", () => {
     const input = screen.getByLabelText("test label")
     await user.type(input, "court")
 
-    await vi.advanceTimersByTimeAsync(300)
+    await vi.advanceTimersByTimeAsync(debounceTimeout)
     const dropdownItems = screen.queryAllByLabelText("dropdown-option")
     expect(dropdownItems).toHaveLength(4)
     expect(dropdownItems[0]).toHaveTextContent("courtlabel1")
     expect(dropdownItems[3]).toHaveTextContent("court neu erstellen")
 
     await user.type(input, "courtlabel1")
-    await vi.advanceTimersByTimeAsync(300)
+    await vi.advanceTimersByTimeAsync(debounceTimeout)
     expect(screen.queryAllByLabelText("dropdown-option")).toHaveLength(1)
     expect(screen.queryAllByLabelText("dropdown-option")[0]).toHaveTextContent(
       "courtlabel1",
@@ -490,7 +490,7 @@ describe("Combobox Element", () => {
     const input = screen.getByLabelText("test label")
     await user.type(input, "testItem1 ")
 
-    await vi.advanceTimersByTimeAsync(300)
+    await vi.advanceTimersByTimeAsync(debounceTimeout)
     const dropdownItems = screen.queryAllByLabelText("dropdown-option")
     expect(dropdownItems).toHaveLength(1)
     expect(dropdownItems[0]).toHaveTextContent("testItem1")
@@ -514,7 +514,7 @@ describe("Combobox Element", () => {
     renderComponent({ noClear: true })
 
     await user.type(screen.getByLabelText("test label"), "court")
-    await vi.advanceTimersByTimeAsync(300)
+    await vi.advanceTimersByTimeAsync(debounceTimeout)
     const dropdownItems = screen.getAllByLabelText("dropdown-option")
     await user.click(dropdownItems[1])
 
@@ -531,13 +531,13 @@ describe("Combobox Element", () => {
     const input = screen.getByLabelText("test label")
     await user.type(input, "x")
 
-    await vi.advanceTimersByTimeAsync(300)
+    await vi.advanceTimersByTimeAsync(debounceTimeout)
     const dropdownItems = screen.getAllByLabelText("dropdown-option")
     expect(dropdownItems).toHaveLength(1)
     expect(dropdownItems[0]).toHaveTextContent("Kein passender Eintrag")
     input.focus()
     await user.keyboard("{Backspace}")
-    await vi.advanceTimersByTimeAsync(300)
+    await vi.advanceTimersByTimeAsync(debounceTimeout)
     expect(screen.getAllByLabelText("dropdown-option")).toHaveLength(3)
     expect(screen.getAllByLabelText("dropdown-option")[0]).toHaveTextContent(
       "courtlabel1",
@@ -549,7 +549,7 @@ describe("Combobox Element", () => {
       renderComponent()
       const input = screen.getByLabelText("test label")
       await fireEvent.focus(input)
-      await vi.advanceTimersByTimeAsync(300)
+      await vi.advanceTimersByTimeAsync(debounceTimeout)
       const items = screen.getAllByLabelText("dropdown-option")
 
       input.focus()
@@ -577,7 +577,7 @@ describe("Combobox Element", () => {
       renderComponent()
       const input = screen.getByLabelText("test label")
       await fireEvent.focus(input)
-      await vi.advanceTimersByTimeAsync(300)
+      await vi.advanceTimersByTimeAsync(debounceTimeout)
       const items = screen.getAllByLabelText("dropdown-option")
 
       input.focus()
@@ -605,7 +605,7 @@ describe("Combobox Element", () => {
       const input = screen.getByLabelText("test label")
       await fireEvent.focus(input)
       await user.type(input, "testItem")
-      await vi.advanceTimersByTimeAsync(300)
+      await vi.advanceTimersByTimeAsync(debounceTimeout)
       const items = screen.getAllByLabelText("dropdown-option")
 
       expect(items[0]).not.toHaveFocus()
@@ -618,7 +618,7 @@ describe("Combobox Element", () => {
       const input = screen.getByLabelText("test label")
       await fireEvent.focus(input)
       await user.type(input, "court")
-      await vi.advanceTimersByTimeAsync(300)
+      await vi.advanceTimersByTimeAsync(debounceTimeout)
       const items = screen.getAllByLabelText("dropdown-option")
 
       // Move to createNewItem link

--- a/frontend/test/components/ensuingDecisions.spec.ts
+++ b/frontend/test/components/ensuingDecisions.spec.ts
@@ -1,14 +1,32 @@
 import { createTestingPinia } from "@pinia/testing"
 import { userEvent } from "@testing-library/user-event"
 import { render, screen } from "@testing-library/vue"
+import { http, HttpResponse } from "msw"
+import { setupServer } from "msw/node"
 import { createRouter, createWebHistory } from "vue-router"
 import EnsuingDecisions from "@/components/EnsuingDecisions.vue"
-import { ComboboxItem } from "@/components/input/types"
 import DocumentUnit, { Court, DocumentType } from "@/domain/documentUnit"
 import EnsuingDecision from "@/domain/ensuingDecision"
-import comboboxItemService from "@/services/comboboxItemService"
 import documentUnitService from "@/services/documentUnitService"
 import routes from "~/test-helper/routes"
+
+const server = setupServer(
+  http.get("/api/v1/caselaw/courts", () => {
+    const court: Court = {
+      type: "AG",
+      location: "Test",
+      label: "AG Test",
+    }
+    return HttpResponse.json([court])
+  }),
+  http.get("/api/v1/caselaw/documenttypes", () => {
+    const documentType: DocumentType = {
+      jurisShortcut: "Ant",
+      label: "EuGH-Vorlage",
+    }
+    return HttpResponse.json([documentType])
+  }),
+)
 
 function renderComponent(ensuingDecisions?: EnsuingDecision[]) {
   const user = userEvent.setup()
@@ -77,6 +95,8 @@ function generateEnsuingDecision(options?: {
 }
 
 describe("EnsuingDecisions", () => {
+  beforeAll(() => server.listen())
+  afterAll(() => server.close())
   vi.spyOn(
     documentUnitService,
     "searchByRelatedDocumentation",
@@ -111,41 +131,6 @@ describe("EnsuingDecisions", () => {
   )
 
   vi.spyOn(window, "scrollTo").mockImplementation(() => vi.fn())
-
-  const court: Court = {
-    type: "AG",
-    location: "Test",
-    label: "AG Test",
-  }
-
-  const documentType: DocumentType = {
-    jurisShortcut: "Ant",
-    label: "EuGH-Vorlage",
-  }
-
-  const dropdownCourtItems: ComboboxItem[] = [
-    {
-      label: court.label,
-      value: court,
-      additionalInformation: court.revoked,
-    },
-  ]
-
-  const dropdownDocumentTypesItems: ComboboxItem[] = [
-    {
-      label: documentType.label,
-      value: documentType,
-      additionalInformation: documentType.jurisShortcut,
-    },
-  ]
-
-  vi.spyOn(comboboxItemService, "getCourts").mockImplementation(() =>
-    Promise.resolve({ status: 200, data: dropdownCourtItems }),
-  )
-
-  vi.spyOn(comboboxItemService, "getDocumentTypes").mockImplementation(() =>
-    Promise.resolve({ status: 200, data: dropdownDocumentTypesItems }),
-  )
 
   it("renders empty ensuing decision in edit mode, when no ensuingDecisions in list", async () => {
     renderComponent()

--- a/frontend/test/e2e/caselaw/categories/editableLists/norms.spec.ts
+++ b/frontend/test/e2e/caselaw/categories/editableLists/norms.spec.ts
@@ -2,7 +2,6 @@ import { expect } from "@playwright/test"
 import SingleNorm from "@/domain/singleNorm"
 import {
   clearInput,
-  fillInput,
   fillNormInputs,
   navigateToCategories,
   save,
@@ -329,8 +328,8 @@ test.describe("norm", () => {
       await navigateToCategories(page, documentNumber)
       const normContainer = page.getByLabel("Norm")
 
-      await page.locator("[aria-label='Gericht']").fill("VerfG")
-      await page.locator("text=VerfG Dessau").last().click()
+      await page.getByLabel("Gericht", { exact: true }).fill("VerfG")
+      await page.getByText("VerfG Dessau").last().click()
 
       await fillNormInputs(page, {
         normAbbreviation: "PBefG",
@@ -355,33 +354,34 @@ test.describe("norm", () => {
       await expect(legalForceRegionCombobox).toBeVisible()
 
       // add new legal force
-      await fillInput(page, "Gesetzeskraft Typ", "Nichtig")
-      await page.getByText("Nichtig").click()
+      await page.getByLabel("Gesetzeskraft Typ").fill("Nichtig")
+      await expect(page.getByLabel("dropdown-option")).toHaveCount(1)
+      await page.getByLabel("dropdown-option").getByText("Nichtig").click()
 
-      await fillInput(page, "Gesetzeskraft Geltungsbereich", "Brandenburg")
-      await page.getByText("Brandenburg").click()
+      await page.getByLabel("Gesetzeskraft Geltungsbereich").fill("Brandenburg")
+      await page.getByLabel("dropdown-option").getByText("Brandenburg").click()
 
       const saveNormButton = normContainer.getByLabel("Norm speichern")
       await saveNormButton.click()
 
       await save(page)
-      await expect(page.locator("text=Nichtig (Brandenburg)")).toBeVisible()
+      await expect(page.getByText("Nichtig (Brandenburg)")).toBeVisible()
 
       // edit legal force
       const listEntries = normContainer.getByLabel("Listen Eintrag")
       await expect(listEntries).toHaveCount(2)
       await normContainer.getByTestId("list-entry-0").click()
 
-      await fillInput(page, "Gesetzeskraft Typ", "Vereinbar")
-      await page.getByText("Vereinbar").click()
+      await page.getByLabel("Gesetzeskraft Typ").fill("Vereinbar")
+      await page.getByLabel("dropdown-option").getByText("Vereinbar").click()
 
-      await fillInput(page, "Gesetzeskraft Geltungsbereich", "Berlin")
-      await page.getByText("Berlin (Ost)").click()
+      await page.getByLabel("Gesetzeskraft Geltungsbereich").fill("Berlin")
+      await page.getByLabel("dropdown-option").getByText("Berlin (Ost)").click()
 
       await saveNormButton.click()
 
       await save(page)
-      await expect(page.locator("text=Vereinbar (Berlin (Ost))")).toBeVisible()
+      await expect(page.getByText("Vereinbar (Berlin (Ost))")).toBeVisible()
 
       // remove legal force
       await normContainer.getByTestId("list-entry-0").click()
@@ -391,15 +391,15 @@ test.describe("norm", () => {
 
       await saveNormButton.click()
       await save(page)
-      await expect(page.locator("text=Vereinbar (Berlin (Ost))")).toBeHidden()
+      await expect(page.getByText("Vereinbar (Berlin (Ost))")).toBeHidden()
     })
 
     test("legal force field validation", async ({ page, documentNumber }) => {
       await navigateToCategories(page, documentNumber)
       const normContainer = page.getByLabel("Norm")
 
-      await page.locator("[aria-label='Gericht']").fill("VerfG")
-      await page.locator("text=VerfG Dessau").last().click()
+      await page.getByLabel("Gericht", { exact: true }).fill("VerfG")
+      await page.getByText("VerfG Dessau").last().click()
 
       await fillNormInputs(page, {
         normAbbreviation: "PBefG",
@@ -426,7 +426,7 @@ test.describe("norm", () => {
       await saveNormButton.click()
 
       await save(page)
-      await expect(page.locator("text=Fehlende Daten")).toBeVisible()
+      await expect(page.getByText("Fehlende Daten")).toBeVisible()
 
       // enter edit mode
       const listEntries = normContainer.getByLabel("Listen Eintrag")
@@ -434,27 +434,23 @@ test.describe("norm", () => {
       await normContainer.getByTestId("list-entry-0").click()
 
       // check that both fields display error message
-      await expect(page.locator("text=Pflichtfeld nicht befüllt")).toHaveCount(
-        2,
-      )
+      await expect(page.getByText("Pflichtfeld nicht befüllt")).toHaveCount(2)
 
-      await page.locator(`[aria-label='Gesetzeskraft Typ']`).fill("Vereinbar")
-      await page.getByText("Vereinbar").click()
+      await page.getByLabel("Gesetzeskraft Typ").fill("Vereinbar")
+      await page.getByText("Vereinbar", { exact: true }).click()
 
       // check that only one field displays error message
-      await expect(page.locator("text=Pflichtfeld nicht befüllt")).toBeVisible()
+      await expect(page.getByText("Pflichtfeld nicht befüllt")).toBeVisible()
 
-      await page
-        .locator(`[aria-label='Gesetzeskraft Geltungsbereich']`)
-        .fill("Berlin")
+      await page.getByLabel("Gesetzeskraft Geltungsbereich").fill("Berlin")
       await page.getByText("Berlin (Ost)").click()
 
-      await expect(page.locator("text=Pflichtfeld nicht befüllt.")).toBeHidden()
+      await expect(page.getByText("Pflichtfeld nicht befüllt.")).toBeHidden()
 
       await saveNormButton.click()
 
       await save(page)
-      await expect(page.locator("text=Vereinbar (Berlin (Ost))")).toBeVisible()
+      await expect(page.getByText("Vereinbar (Berlin (Ost))")).toBeVisible()
     })
   })
 

--- a/frontend/test/e2e/caselaw/e2e-utils.ts
+++ b/frontend/test/e2e/caselaw/e2e-utils.ts
@@ -255,6 +255,10 @@ export async function documentUnitExists(
   ).includes("uuid")
 }
 
+/**
+ * @deprecated
+ * Use playwright's toHaveValue instead: e.g. <pre>page.getByLabel("Gericht").toHaveValue("BGH")</pre>
+ */
 export async function waitForInputValue(
   page: Page,
   selector: string,

--- a/frontend/test/services/comboboxItemService.spec.ts
+++ b/frontend/test/services/comboboxItemService.spec.ts
@@ -1,129 +1,47 @@
-import { ComboboxItem } from "@/components/input/types"
-import { Court } from "@/domain/documentUnit"
+import { http, HttpResponse } from "msw"
+import { setupServer } from "msw/node"
+import { ref } from "vue"
+import { Court, DocumentType } from "@/domain/documentUnit"
 import service from "@/services/comboboxItemService"
-import httpClient from "@/services/httpClient"
 
-vi.mock("@/services/httpClient")
+const court: Court = {
+  type: "BGH",
+  location: "Karlsruhe",
+  label: "BGH Karlsruhe",
+}
+const doctype: DocumentType = {
+  jurisShortcut: "AO",
+  label: "Anordnung",
+}
+const server = setupServer(
+  http.get("/api/v1/caselaw/courts", () => HttpResponse.json([court])),
+  http.get("/api/v1/caselaw/documenttypes", () => HttpResponse.json([doctype])),
+)
 
 describe("comboboxItemService", () => {
+  beforeAll(() => server.listen())
+  afterAll(() => server.close())
   beforeEach(() => {
     vi.resetAllMocks()
   })
 
   it("should fetch document type from lookup table", async () => {
-    const doctype = {
-      jurisShortcut: "AO",
-      label: "Anordnung",
-    }
+    const { data, execute } = service.getDocumentTypes(ref())
 
-    const httpClientGet = vi
-      .mocked(httpClient)
-      .get.mockResolvedValueOnce({ status: 200, data: [doctype] })
+    await execute()
+    await new Promise((resolve) => setTimeout(resolve))
 
-    const result = (await service.getDocumentTypes()).data as ComboboxItem[]
-
-    expect(httpClientGet).toHaveBeenCalledOnce()
-    expect(result[0].label).toEqual("Anordnung")
-    expect(result[0].value).toEqual(doctype)
+    expect(data.value?.[0].label).toEqual("Anordnung")
+    expect(data.value?.[0].value).toEqual(doctype)
   })
 
   it("should fetch court from lookup table", async () => {
-    const court: Court = {
-      type: "BGH",
-      location: "Karlsruhe",
-      label: "BGH Karlsruhe",
-    }
+    const { data, execute } = service.getCourts(ref())
 
-    const httpClientGet = vi
-      .mocked(httpClient)
-      .get.mockResolvedValueOnce({ status: 200, data: [court] })
+    await execute()
+    await new Promise((resolve) => setTimeout(resolve))
 
-    const result = (await service.getCourts()).data as ComboboxItem[]
-
-    expect(httpClientGet).toHaveBeenCalledOnce()
-    expect(result[0].label).toEqual("BGH Karlsruhe")
-    expect(result[0].value).toEqual(court)
-  })
-
-  it("should return local items if no filter", async () => {
-    const result = (
-      await service.filterItems([
-        {
-          label: "testItem1",
-          value: {
-            type: "courttype1",
-            location: "courtlocation1",
-            label: "courtlabel1",
-          },
-        },
-        {
-          label: "testItem2",
-          value: {
-            type: "courttype1",
-            location: "courtlocation1",
-            label: "courtlabel1",
-          },
-        },
-        {
-          label: "testItem3",
-          value: {
-            type: "courttype1",
-            location: "courtlocation1",
-            label: "courtlabel1",
-          },
-        },
-      ])()
-    ).data as ComboboxItem[]
-
-    expect(result.length).toEqual(3)
-    expect(result[1]).toEqual({
-      label: "testItem2",
-      value: {
-        type: "courttype1",
-        location: "courtlocation1",
-        label: "courtlabel1",
-      },
-    })
-  })
-
-  it("should filter local items", async () => {
-    const result = (
-      await service.filterItems([
-        {
-          label: "testItem1",
-          value: {
-            type: "courttype1",
-            location: "courtlocation1",
-            label: "courtlabel1",
-          },
-        },
-        {
-          label: "testItem2",
-          value: {
-            type: "courttype1",
-            location: "courtlocation1",
-            label: "courtlabel1",
-          },
-        },
-        {
-          label: "testItem3",
-          value: {
-            type: "courttype1",
-            location: "courtlocation1",
-            label: "courtlabel1",
-          },
-        },
-      ])("Item3")
-    ).data as ComboboxItem[]
-
-    expect(result.length).toEqual(1)
-    expect(result[0]).toEqual({
-      label: "testItem3",
-      value: {
-        type: "courttype1",
-        location: "courtlocation1",
-        label: "courtlabel1",
-      },
-    })
+    expect(data.value?.[0].label).toEqual("BGH Karlsruhe")
+    expect(data.value?.[0].value).toEqual(court)
   })
 })


### PR DESCRIPTION
RISDEV-5663
Previously: Requests on every keystroke. Now, we debounce and cancel requests. Also, when enter is pressed while a search is ongoing, we defer the enter to select the first item to when the request resolves.