### PR TITLE
Use directive to trigger search with ctrl + enter shortcut in all searches

### DIFF
--- a/frontend/src/components/ActiveCitationInput.vue
+++ b/frontend/src/components/ActiveCitationInput.vue
@@ -212,7 +212,7 @@ onMounted(() => {
 </script>
 
 <template>
-  <div class="flex flex-col gap-24">
+  <div v-search="search" class="flex flex-col gap-24">
     <InputField
       id="activeCitationPredicate"
       v-slot="slotProps"

--- a/frontend/src/components/ActiveCitationInput.vue
+++ b/frontend/src/components/ActiveCitationInput.vue
@@ -212,7 +212,7 @@ onMounted(() => {
 </script>
 
 <template>
-  <div v-search="search" class="flex flex-col gap-24">
+  <div v-ctrl-enter="search" class="flex flex-col gap-24">
     <InputField
       id="activeCitationPredicate"
       v-slot="slotProps"

--- a/frontend/src/components/DocumentUnitSearchEntryForm.vue
+++ b/frontend/src/components/DocumentUnitSearchEntryForm.vue
@@ -217,7 +217,7 @@ export type DocumentUnitSearchParameter =
 
 <template>
   <div
-    v-search="handleSearchButtonClicked"
+    v-ctrl-enter="handleSearchButtonClicked"
     class="pyb-24 mb-32 flex flex-col bg-blue-200"
   >
     <div

--- a/frontend/src/components/DocumentUnitSearchEntryForm.vue
+++ b/frontend/src/components/DocumentUnitSearchEntryForm.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import { computed, onMounted, onUnmounted, ref, watch } from "vue"
+import { computed, ref, watch } from "vue"
 import Checkbox from "@/components/input/CheckboxInput.vue"
 import DateInput from "@/components/input/DateInput.vue"
 import DropdownInput from "@/components/input/DropdownInput.vue"
@@ -183,11 +183,6 @@ function handleSearchButtonClicked() {
   pushQueryToRoute(query.value)
 }
 
-function handleSearchShortcut(event: KeyboardEvent) {
-  if (event.key == "Enter" && (event.ctrlKey || event.metaKey))
-    handleSearchButtonClicked()
-}
-
 function handleSearch() {
   if (!isEmptySearch.value) {
     emit("search", getQueryFromRoute())
@@ -201,17 +196,8 @@ watch(
   () => {
     handleSearch()
   },
-  { deep: true },
+  { deep: true, immediate: true },
 )
-
-onMounted(async () => {
-  handleSearch()
-  window.addEventListener("keydown", handleSearchShortcut)
-})
-
-onUnmounted(() => {
-  window.removeEventListener("keydown", handleSearchShortcut)
-})
 </script>
 
 <script lang="ts">
@@ -230,7 +216,10 @@ export type DocumentUnitSearchParameter =
 </script>
 
 <template>
-  <div class="pyb-24 mb-32 flex flex-col bg-blue-200">
+  <div
+    v-search="handleSearchButtonClicked"
+    class="pyb-24 mb-32 flex flex-col bg-blue-200"
+  >
     <div
       class="m-40 grid grid-flow-col grid-cols-[auto_1fr_auto_1fr] grid-rows-[auto_auto_auto_auto_auto] gap-x-12 gap-y-20 lg:gap-x-32"
     >

--- a/frontend/src/components/EnsuingDecisionInputGroup.vue
+++ b/frontend/src/components/EnsuingDecisionInputGroup.vue
@@ -184,7 +184,7 @@ onMounted(() => {
 </script>
 
 <template>
-  <div v-search="search" class="flex flex-col gap-24">
+  <div v-ctrl-enter="search" class="flex flex-col gap-24">
     <div class="flex flex-col gap-24">
       <InputField
         id="isPending"

--- a/frontend/src/components/EnsuingDecisionInputGroup.vue
+++ b/frontend/src/components/EnsuingDecisionInputGroup.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import { watch, ref, computed, onMounted } from "vue"
+import { computed, onMounted, ref, watch } from "vue"
 import { ValidationError } from "./input/types"
 import SearchResultList, { SearchResults } from "./SearchResultList.vue"
 import ComboboxInput from "@/components/ComboboxInput.vue"
@@ -184,7 +184,7 @@ onMounted(() => {
 </script>
 
 <template>
-  <div class="flex flex-col gap-24">
+  <div v-search="search" class="flex flex-col gap-24">
     <div class="flex flex-col gap-24">
       <InputField
         id="isPending"

--- a/frontend/src/components/PreviousDecisionInputGroup.vue
+++ b/frontend/src/components/PreviousDecisionInputGroup.vue
@@ -179,7 +179,7 @@ onMounted(async () => {
 </script>
 
 <template>
-  <div v-search="search" class="flex flex-col gap-24">
+  <div v-ctrl-enter="search" class="flex flex-col gap-24">
     <div class="flex flex-col gap-24">
       <InputField
         id="dateKnown"

--- a/frontend/src/components/PreviousDecisionInputGroup.vue
+++ b/frontend/src/components/PreviousDecisionInputGroup.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import { watch, ref, computed, onMounted } from "vue"
+import { computed, onMounted, ref, watch } from "vue"
 import { ValidationError } from "./input/types"
 import SearchResultList, { SearchResults } from "./SearchResultList.vue"
 import ComboboxInput from "@/components/ComboboxInput.vue"
@@ -179,7 +179,7 @@ onMounted(async () => {
 </script>
 
 <template>
-  <div class="flex flex-col gap-24">
+  <div v-search="search" class="flex flex-col gap-24">
     <div class="flex flex-col gap-24">
       <InputField
         id="dateKnown"

--- a/frontend/src/components/input/TextButton.vue
+++ b/frontend/src/components/input/TextButton.vue
@@ -91,7 +91,7 @@ const render = () => {
 </script>
 
 <template>
-  <div class="w-max" data-testid>
+  <div class="w-full" data-testid>
     <render />
   </div>
 </template>

--- a/frontend/src/components/periodical-evaluation/references/PeriodicalEditionReferenceInput.vue
+++ b/frontend/src/components/periodical-evaluation/references/PeriodicalEditionReferenceInput.vue
@@ -324,7 +324,7 @@ onMounted(async () => {
 </script>
 
 <template>
-  <div ref="containerRef" class="flex flex-col border-b-1">
+  <div ref="containerRef" v-search="search" class="flex flex-col border-b-1">
     <PopupModal
       v-if="showModal"
       aria-label="Dialog zur Auswahl der Löschaktion"

--- a/frontend/src/components/periodical-evaluation/references/PeriodicalEditionReferenceInput.vue
+++ b/frontend/src/components/periodical-evaluation/references/PeriodicalEditionReferenceInput.vue
@@ -324,7 +324,11 @@ onMounted(async () => {
 </script>
 
 <template>
-  <div ref="containerRef" v-search="search" class="flex flex-col border-b-1">
+  <div
+    ref="containerRef"
+    v-ctrl-enter="search"
+    class="flex flex-col border-b-1"
+  >
     <PopupModal
       v-if="showModal"
       aria-label="Dialog zur Auswahl der Löschaktion"

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -7,10 +7,12 @@ import App from "./App.vue"
 import router from "./router"
 import useSessionStore from "./stores/sessionStore"
 import { filterConsoleWarnings } from "@/utils/filterConsoleWarnings"
+import { searchShortcutDirective } from "@/utils/searchShortcutDirective"
 
 filterConsoleWarnings()
 
 const app = createApp(App)
+app.directive("search", searchShortcutDirective)
 app.use(createHead())
 
 function targets(): string[] {

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -7,12 +7,12 @@ import App from "./App.vue"
 import router from "./router"
 import useSessionStore from "./stores/sessionStore"
 import { filterConsoleWarnings } from "@/utils/filterConsoleWarnings"
-import { searchShortcutDirective } from "@/utils/searchShortcutDirective"
+import { onSearchShortcutDirective } from "@/utils/onSearchShortcutDirective"
 
 filterConsoleWarnings()
 
 const app = createApp(App)
-app.directive("search", searchShortcutDirective)
+app.directive("ctrl-enter", onSearchShortcutDirective)
 app.use(createHead())
 
 function targets(): string[] {

--- a/frontend/src/routes/caselaw/periodical-evaluation/[editionId].vue
+++ b/frontend/src/routes/caselaw/periodical-evaluation/[editionId].vue
@@ -75,7 +75,7 @@ const handleKeyDown = (event: KeyboardEvent) => {
   }
 
   switch (event.key) {
-    case "<": // Ctrl + [
+    case "<":
       toggleNavigationPanel()
       break
     case "x":

--- a/frontend/src/utils/onSearchShortcutDirective.ts
+++ b/frontend/src/utils/onSearchShortcutDirective.ts
@@ -1,6 +1,6 @@
 import { Directive } from "vue"
 
-export const searchShortcutDirective: Directive = {
+export const onSearchShortcutDirective: Directive = {
   mounted(el, binding) {
     const handleKeydown = (event: KeyboardEvent) => {
       if (

--- a/frontend/src/utils/searchShortcutDirective.ts
+++ b/frontend/src/utils/searchShortcutDirective.ts
@@ -1,0 +1,22 @@
+import { Directive } from "vue"
+
+export const searchShortcutDirective: Directive = {
+  mounted(el, binding) {
+    const handleKeydown = (event: KeyboardEvent) => {
+      if (
+        el.contains(document.activeElement) && // Ensure focus is inside the element
+        event.key === "Enter" &&
+        (event.ctrlKey || event.metaKey)
+      ) {
+        binding.value?.(event) // Call the provided callback
+      }
+    }
+
+    el.__handleKeydown__ = handleKeydown // Store reference for cleanup
+    window.addEventListener("keydown", handleKeydown)
+  },
+  unmounted(el) {
+    window.removeEventListener("keydown", el.__handleKeydown__)
+    delete el.__handleKeydown__
+  },
+}

--- a/frontend/test/components/activeCitations.spec.ts
+++ b/frontend/test/components/activeCitations.spec.ts
@@ -10,7 +10,7 @@ import { CitationType } from "@/domain/citationType"
 import DocumentUnit, { Court, DocumentType } from "@/domain/documentUnit"
 import documentUnitService from "@/services/documentUnitService"
 import featureToggleService from "@/services/featureToggleService"
-import { searchShortcutDirective } from "@/utils/searchShortcutDirective"
+import { onSearchShortcutDirective } from "@/utils/onSearchShortcutDirective"
 import routes from "~/test-helper/routes"
 
 const server = setupServer(
@@ -50,7 +50,7 @@ function renderComponent(activeCitations?: ActiveCitation[]) {
     user,
     ...render(ActiveCitations, {
       global: {
-        directives: { search: searchShortcutDirective },
+        directives: { "ctrl-enter": onSearchShortcutDirective },
         plugins: [
           [
             createTestingPinia({
@@ -69,7 +69,11 @@ function renderComponent(activeCitations?: ActiveCitation[]) {
           ],
           [router],
         ],
-        stubs: { routerLink: { template: "<a><slot/></a>" } },
+        stubs: {
+          routerLink: {
+            template: "<a><slot/></a>",
+          },
+        },
       },
     }),
   }

--- a/frontend/test/components/activeCitations.spec.ts
+++ b/frontend/test/components/activeCitations.spec.ts
@@ -10,6 +10,7 @@ import { CitationType } from "@/domain/citationType"
 import DocumentUnit, { Court, DocumentType } from "@/domain/documentUnit"
 import documentUnitService from "@/services/documentUnitService"
 import featureToggleService from "@/services/featureToggleService"
+import { searchShortcutDirective } from "@/utils/searchShortcutDirective"
 import routes from "~/test-helper/routes"
 
 const server = setupServer(
@@ -49,6 +50,7 @@ function renderComponent(activeCitations?: ActiveCitation[]) {
     user,
     ...render(ActiveCitations, {
       global: {
+        directives: { search: searchShortcutDirective },
         plugins: [
           [
             createTestingPinia({
@@ -385,6 +387,19 @@ describe("active citations", () => {
 
     expect(screen.queryByText(/test fileNumber/)).not.toBeInTheDocument()
     await user.click(await screen.findByLabelText("Nach Entscheidung suchen"))
+
+    expect(screen.getAllByText(/test fileNumber/).length).toBe(1)
+  })
+
+  it("search is triggered with shortcut", async () => {
+    const { user } = renderComponent()
+
+    expect(screen.queryByText(/test fileNumber/)).not.toBeInTheDocument()
+    await user.type(
+      await screen.findByLabelText("Aktenzeichen Aktivzitierung"),
+      "test",
+    )
+    await user.keyboard("{Control>}{Enter}")
 
     expect(screen.getAllByText(/test fileNumber/).length).toBe(1)
   })

--- a/frontend/test/components/documentUnit/documentUnitCategories.spec.ts
+++ b/frontend/test/components/documentUnit/documentUnitCategories.spec.ts
@@ -4,7 +4,7 @@ import { render, screen } from "@testing-library/vue"
 import { createRouter, createWebHistory } from "vue-router"
 import DocumentUnitCategories from "@/components/DocumentUnitCategories.vue"
 import DocumentUnit from "@/domain/documentUnit"
-import { searchShortcutDirective } from "@/utils/searchShortcutDirective"
+import { onSearchShortcutDirective } from "@/utils/onSearchShortcutDirective"
 import routes from "~/test-helper/routes"
 
 function renderComponent() {
@@ -18,7 +18,7 @@ function renderComponent() {
     user,
     ...render(DocumentUnitCategories, {
       global: {
-        directives: { search: searchShortcutDirective },
+        directives: { "ctrl-enter": onSearchShortcutDirective },
         plugins: [
           createTestingPinia({
             initialState: {

--- a/frontend/test/components/documentUnit/documentUnitCategories.spec.ts
+++ b/frontend/test/components/documentUnit/documentUnitCategories.spec.ts
@@ -4,6 +4,7 @@ import { render, screen } from "@testing-library/vue"
 import { createRouter, createWebHistory } from "vue-router"
 import DocumentUnitCategories from "@/components/DocumentUnitCategories.vue"
 import DocumentUnit from "@/domain/documentUnit"
+import { searchShortcutDirective } from "@/utils/searchShortcutDirective"
 import routes from "~/test-helper/routes"
 
 function renderComponent() {
@@ -17,6 +18,7 @@ function renderComponent() {
     user,
     ...render(DocumentUnitCategories, {
       global: {
+        directives: { search: searchShortcutDirective },
         plugins: [
           createTestingPinia({
             initialState: {

--- a/frontend/test/components/documentUnit/documentUnitSearch.spec.ts
+++ b/frontend/test/components/documentUnit/documentUnitSearch.spec.ts
@@ -9,7 +9,7 @@ import { Court } from "@/domain/documentUnit"
 import DocumentUnitListEntry from "@/domain/documentUnitListEntry"
 import authService from "@/services/authService"
 import documentUnitService from "@/services/documentUnitService"
-import { searchShortcutDirective } from "@/utils/searchShortcutDirective"
+import { onSearchShortcutDirective } from "@/utils/onSearchShortcutDirective"
 import routes from "~/test-helper/routes"
 
 const server = setupServer(
@@ -36,7 +36,7 @@ function renderComponent(
     user,
     ...render(DocumentUnitSearch, {
       global: {
-        directives: { search: searchShortcutDirective },
+        directives: { "ctrl-enter": onSearchShortcutDirective },
         plugins: [
           router,
           createTestingPinia({

--- a/frontend/test/components/documentUnit/documentUnitSearchEntryForm.spec.ts
+++ b/frontend/test/components/documentUnit/documentUnitSearchEntryForm.spec.ts
@@ -3,6 +3,7 @@ import { render, screen } from "@testing-library/vue"
 import { expect } from "vitest"
 import { createRouter, createWebHistory } from "vue-router"
 import DocumentUnitSearchEntryForm from "@/components/DocumentUnitSearchEntryForm.vue"
+import { searchShortcutDirective } from "@/utils/searchShortcutDirective"
 
 async function renderComponent(options?: { isLoading: boolean }) {
   const props = {
@@ -23,7 +24,12 @@ async function renderComponent(options?: { isLoading: boolean }) {
   return {
     ...render(DocumentUnitSearchEntryForm, {
       props,
-      global: { plugins: [router] },
+      global: {
+        directives: {
+          search: searchShortcutDirective,
+        },
+        plugins: [router],
+      },
     }),
     user: userEvent.setup(),
     router: router,

--- a/frontend/test/components/documentUnit/documentUnitSearchEntryForm.spec.ts
+++ b/frontend/test/components/documentUnit/documentUnitSearchEntryForm.spec.ts
@@ -3,7 +3,7 @@ import { render, screen } from "@testing-library/vue"
 import { expect } from "vitest"
 import { createRouter, createWebHistory } from "vue-router"
 import DocumentUnitSearchEntryForm from "@/components/DocumentUnitSearchEntryForm.vue"
-import { searchShortcutDirective } from "@/utils/searchShortcutDirective"
+import { onSearchShortcutDirective } from "@/utils/onSearchShortcutDirective"
 
 async function renderComponent(options?: { isLoading: boolean }) {
   const props = {
@@ -26,7 +26,7 @@ async function renderComponent(options?: { isLoading: boolean }) {
       props,
       global: {
         directives: {
-          search: searchShortcutDirective,
+          "ctrl-enter": onSearchShortcutDirective,
         },
         plugins: [router],
       },

--- a/frontend/test/components/ensuingDecisions.spec.ts
+++ b/frontend/test/components/ensuingDecisions.spec.ts
@@ -9,7 +9,7 @@ import DocumentUnit, { Court, DocumentType } from "@/domain/documentUnit"
 import EnsuingDecision from "@/domain/ensuingDecision"
 import documentUnitService from "@/services/documentUnitService"
 import featureToggleService from "@/services/featureToggleService"
-import { searchShortcutDirective } from "@/utils/searchShortcutDirective"
+import { onSearchShortcutDirective } from "@/utils/onSearchShortcutDirective"
 import routes from "~/test-helper/routes"
 
 const server = setupServer(
@@ -42,7 +42,9 @@ function renderComponent(ensuingDecisions?: EnsuingDecision[]) {
     user,
     ...render(EnsuingDecisions, {
       global: {
-        directives: { search: searchShortcutDirective },
+        directives: {
+          "ctrl-enter": onSearchShortcutDirective,
+        },
         plugins: [
           [
             createTestingPinia({
@@ -59,7 +61,11 @@ function renderComponent(ensuingDecisions?: EnsuingDecision[]) {
           ],
           [router],
         ],
-        stubs: { routerLink: { template: "<a><slot/></a>" } },
+        stubs: {
+          routerLink: {
+            template: "<a><slot/></a>",
+          },
+        },
       },
     }),
   }

--- a/frontend/test/components/ensuingDecisions.spec.ts
+++ b/frontend/test/components/ensuingDecisions.spec.ts
@@ -9,6 +9,7 @@ import DocumentUnit, { Court, DocumentType } from "@/domain/documentUnit"
 import EnsuingDecision from "@/domain/ensuingDecision"
 import documentUnitService from "@/services/documentUnitService"
 import featureToggleService from "@/services/featureToggleService"
+import { searchShortcutDirective } from "@/utils/searchShortcutDirective"
 import routes from "~/test-helper/routes"
 
 const server = setupServer(
@@ -41,6 +42,7 @@ function renderComponent(ensuingDecisions?: EnsuingDecision[]) {
     user,
     ...render(EnsuingDecisions, {
       global: {
+        directives: { search: searchShortcutDirective },
         plugins: [
           [
             createTestingPinia({
@@ -322,6 +324,19 @@ describe("EnsuingDecisions", () => {
 
     expect(screen.queryByText(/test fileNumber/)).not.toBeInTheDocument()
     await user.click(await screen.findByLabelText("Nach Entscheidung suchen"))
+
+    expect(screen.getAllByText(/test fileNumber/).length).toBe(1)
+  })
+
+  it("search is triggered with shortcut", async () => {
+    const { user } = renderComponent()
+
+    expect(screen.queryByText(/test fileNumber/)).not.toBeInTheDocument()
+    await user.type(
+      await screen.findByLabelText("Aktenzeichen Nachgehende Entscheidung"),
+      "test",
+    )
+    await user.keyboard("{Control>}{Enter}")
 
     expect(screen.getAllByText(/test fileNumber/).length).toBe(1)
   })

--- a/frontend/test/components/periodicalEvaluation/editionReferenceInput.spec.ts
+++ b/frontend/test/components/periodicalEvaluation/editionReferenceInput.spec.ts
@@ -77,6 +77,7 @@ describe("Legal periodical edition reference input", () => {
   })
 
   it("search is triggered with shortcut", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => null)
     const { user } = renderComponent()
 
     expect(screen.queryByText(/test fileNumber1/)).not.toBeInTheDocument()

--- a/frontend/test/components/periodicalEvaluation/editionReferenceInput.spec.ts
+++ b/frontend/test/components/periodicalEvaluation/editionReferenceInput.spec.ts
@@ -5,7 +5,7 @@ import { createRouter, createWebHistory } from "vue-router"
 import PeriodicalEditionReferenceInput from "@/components/periodical-evaluation/references/PeriodicalEditionReferenceInput.vue"
 import RelatedDocumentation from "@/domain/relatedDocumentation"
 import documentUnitService from "@/services/documentUnitService"
-import { searchShortcutDirective } from "@/utils/searchShortcutDirective"
+import { onSearchShortcutDirective } from "@/utils/onSearchShortcutDirective"
 import routes from "~/test-helper/routes"
 
 function renderComponent() {
@@ -23,7 +23,7 @@ function renderComponent() {
         isSaved: false,
       },
       global: {
-        directives: { search: searchShortcutDirective },
+        directives: { "ctrl-enter": onSearchShortcutDirective },
         plugins: [
           router,
           [

--- a/frontend/test/components/periodicalEvaluation/editionReferenceInput.spec.ts
+++ b/frontend/test/components/periodicalEvaluation/editionReferenceInput.spec.ts
@@ -5,6 +5,7 @@ import { createRouter, createWebHistory } from "vue-router"
 import PeriodicalEditionReferenceInput from "@/components/periodical-evaluation/references/PeriodicalEditionReferenceInput.vue"
 import RelatedDocumentation from "@/domain/relatedDocumentation"
 import documentUnitService from "@/services/documentUnitService"
+import { searchShortcutDirective } from "@/utils/searchShortcutDirective"
 import routes from "~/test-helper/routes"
 
 function renderComponent() {
@@ -22,6 +23,7 @@ function renderComponent() {
         isSaved: false,
       },
       global: {
+        directives: { search: searchShortcutDirective },
         plugins: [
           router,
           [
@@ -72,6 +74,16 @@ describe("Legal periodical edition reference input", () => {
         },
       }),
     )
+  })
+
+  it("search is triggered with shortcut", async () => {
+    const { user } = renderComponent()
+
+    expect(screen.queryByText(/test fileNumber1/)).not.toBeInTheDocument()
+    await user.type(await screen.findByLabelText("Aktenzeichen"), "test")
+    await user.keyboard("{Control>}{Enter}")
+
+    expect(screen.getAllByText(/test fileNumber1/).length).toBe(1)
   })
 
   test("adding a decision scrolls to reference on validation errors", async () => {

--- a/frontend/test/components/periodicalEvaluation/editionReferences.spec.ts
+++ b/frontend/test/components/periodicalEvaluation/editionReferences.spec.ts
@@ -13,6 +13,7 @@ import documentUnitService from "@/services/documentUnitService"
 import featureToggleService from "@/services/featureToggleService"
 import { ServiceResponse } from "@/services/httpClient"
 import service from "@/services/legalPeriodicalEditionService"
+import { searchShortcutDirective } from "@/utils/searchShortcutDirective"
 import testRoutes from "~/test-helper/routes"
 
 const editionUUid = crypto.randomUUID()
@@ -56,6 +57,7 @@ async function renderComponent(options?: { references?: Reference[] }) {
     user,
     ...render(PeriodicalEditionReferences, {
       global: {
+        directives: { search: searchShortcutDirective },
         plugins: [router, pinia],
       },
     }),

--- a/frontend/test/components/periodicalEvaluation/editionReferences.spec.ts
+++ b/frontend/test/components/periodicalEvaluation/editionReferences.spec.ts
@@ -13,7 +13,7 @@ import documentUnitService from "@/services/documentUnitService"
 import featureToggleService from "@/services/featureToggleService"
 import { ServiceResponse } from "@/services/httpClient"
 import service from "@/services/legalPeriodicalEditionService"
-import { searchShortcutDirective } from "@/utils/searchShortcutDirective"
+import { onSearchShortcutDirective } from "@/utils/onSearchShortcutDirective"
 import testRoutes from "~/test-helper/routes"
 
 const editionUUid = crypto.randomUUID()
@@ -57,7 +57,7 @@ async function renderComponent(options?: { references?: Reference[] }) {
     user,
     ...render(PeriodicalEditionReferences, {
       global: {
-        directives: { search: searchShortcutDirective },
+        directives: { "ctrl-enter": onSearchShortcutDirective },
         plugins: [router, pinia],
       },
     }),

--- a/frontend/test/components/previousDecisions.spec.ts
+++ b/frontend/test/components/previousDecisions.spec.ts
@@ -9,6 +9,7 @@ import DocumentUnit, { Court, DocumentType } from "@/domain/documentUnit"
 import PreviousDecision from "@/domain/previousDecision"
 import documentUnitService from "@/services/documentUnitService"
 import featureToggleService from "@/services/featureToggleService"
+import { searchShortcutDirective } from "@/utils/searchShortcutDirective"
 import routes from "~/test-helper/routes"
 
 const server = setupServer(
@@ -40,6 +41,7 @@ function renderComponent(previousDecisions?: PreviousDecision[]) {
     user,
     ...render(PreviousDecisions, {
       global: {
+        directives: { search: searchShortcutDirective },
         stubs: { routerLink: { template: "<a><slot/></a>" } },
         plugins: [
           [
@@ -353,6 +355,19 @@ describe("PreviousDecisions", () => {
 
     expect(screen.queryByText(/test fileNumber/)).not.toBeInTheDocument()
     await user.click(await screen.findByLabelText("Nach Entscheidung suchen"))
+
+    expect(screen.getAllByText(/test fileNumber/).length).toBe(1)
+  })
+
+  it("search is triggered with shortcut", async () => {
+    const { user } = renderComponent()
+
+    expect(screen.queryByText(/test fileNumber/)).not.toBeInTheDocument()
+    await user.type(
+      await screen.findByLabelText("Aktenzeichen Vorgehende Entscheidung"),
+      "test",
+    )
+    await user.keyboard("{Control>}{Enter}")
 
     expect(screen.getAllByText(/test fileNumber/).length).toBe(1)
   })

--- a/frontend/test/components/previousDecisions.spec.ts
+++ b/frontend/test/components/previousDecisions.spec.ts
@@ -9,7 +9,7 @@ import DocumentUnit, { Court, DocumentType } from "@/domain/documentUnit"
 import PreviousDecision from "@/domain/previousDecision"
 import documentUnitService from "@/services/documentUnitService"
 import featureToggleService from "@/services/featureToggleService"
-import { searchShortcutDirective } from "@/utils/searchShortcutDirective"
+import { onSearchShortcutDirective } from "@/utils/onSearchShortcutDirective"
 import routes from "~/test-helper/routes"
 
 const server = setupServer(
@@ -41,8 +41,12 @@ function renderComponent(previousDecisions?: PreviousDecision[]) {
     user,
     ...render(PreviousDecisions, {
       global: {
-        directives: { search: searchShortcutDirective },
-        stubs: { routerLink: { template: "<a><slot/></a>" } },
+        directives: { "ctrl-enter": onSearchShortcutDirective },
+        stubs: {
+          routerLink: {
+            template: "<a><slot/></a>",
+          },
+        },
         plugins: [
           [
             createTestingPinia({

--- a/frontend/test/routes/[documentNumber].spec.ts
+++ b/frontend/test/routes/[documentNumber].spec.ts
@@ -9,6 +9,7 @@ import DocumentNumber from "@/routes/caselaw/documentUnit/[documentNumber].vue"
 import documentUnitService from "@/services/documentUnitService"
 import featureToggleService from "@/services/featureToggleService"
 import { ServiceResponse } from "@/services/httpClient"
+import { searchShortcutDirective } from "@/utils/searchShortcutDirective"
 
 function renderComponent() {
   const user = userEvent.setup()
@@ -71,6 +72,7 @@ function renderComponent() {
         documentNumber: "1234567891234",
       },
       global: {
+        directives: { search: searchShortcutDirective },
         plugins: [
           head,
           router,

--- a/frontend/test/routes/[documentNumber].spec.ts
+++ b/frontend/test/routes/[documentNumber].spec.ts
@@ -9,7 +9,7 @@ import DocumentNumber from "@/routes/caselaw/documentUnit/[documentNumber].vue"
 import documentUnitService from "@/services/documentUnitService"
 import featureToggleService from "@/services/featureToggleService"
 import { ServiceResponse } from "@/services/httpClient"
-import { searchShortcutDirective } from "@/utils/searchShortcutDirective"
+import { onSearchShortcutDirective } from "@/utils/onSearchShortcutDirective"
 
 function renderComponent() {
   const user = userEvent.setup()
@@ -72,7 +72,7 @@ function renderComponent() {
         documentNumber: "1234567891234",
       },
       global: {
-        directives: { search: searchShortcutDirective },
+        directives: { "ctrl-enter": onSearchShortcutDirective },
         plugins: [
           head,
           router,

--- a/frontend/test/routes/[editionId].spec.ts
+++ b/frontend/test/routes/[editionId].spec.ts
@@ -14,7 +14,7 @@ import featureToggleService from "@/services/featureToggleService"
 import { ServiceResponse } from "@/services/httpClient"
 import LegalPeriodicalEditionService from "@/services/legalPeriodicalEditionService"
 import { useDocumentUnitStore } from "@/stores/documentUnitStore"
-import { searchShortcutDirective } from "@/utils/searchShortcutDirective"
+import { onSearchShortcutDirective } from "@/utils/onSearchShortcutDirective"
 
 const editionUuid = crypto.randomUUID()
 const legalPeriodical: LegalPeriodical = {
@@ -63,7 +63,7 @@ function renderComponent() {
     router,
     ...render(EditionId, {
       global: {
-        directives: { search: searchShortcutDirective },
+        directives: { "ctrl-enter": onSearchShortcutDirective },
         plugins: [
           router,
           [

--- a/frontend/test/routes/[editionId].spec.ts
+++ b/frontend/test/routes/[editionId].spec.ts
@@ -14,6 +14,7 @@ import featureToggleService from "@/services/featureToggleService"
 import { ServiceResponse } from "@/services/httpClient"
 import LegalPeriodicalEditionService from "@/services/legalPeriodicalEditionService"
 import { useDocumentUnitStore } from "@/stores/documentUnitStore"
+import { searchShortcutDirective } from "@/utils/searchShortcutDirective"
 
 const editionUuid = crypto.randomUUID()
 const legalPeriodical: LegalPeriodical = {
@@ -62,6 +63,7 @@ function renderComponent() {
     router,
     ...render(EditionId, {
       global: {
+        directives: { search: searchShortcutDirective },
         plugins: [
           router,
           [


### PR DESCRIPTION
I added a [vue directive](https://vuejs.org/guide/reusability/custom-directives.html) that allows components to react to `ctrl` + `enter` shortcuts. The action is only triggered if it the shortcut is pressed within the active/focused component. This makes sure that, when the user enters data in active citation, only the active citation small search is triggered but not the previous decision search (see the if clause in handleKeydown()) --> [link to file](https://github.com/digitalservicebund/ris-backend-service/blob/bddfd7b0129ec6e4a51fee77aabea8d02454decd/frontend/src/utils/searchShortcutDirective.ts)

```
import { Directive } from "vue"

export const searchShortcutDirective: Directive = {
  mounted(el, binding) {
    const handleKeydown = (event: KeyboardEvent) => {
      if (
        el.contains(document.activeElement) && // Ensure focus is inside the element
        event.key === "Enter" &&
        (event.ctrlKey || event.metaKey)
      ) {
        binding.value?.(event) // Call the provided callback
      }
    }

    el.__handleKeydown__ = handleKeydown // Store reference for cleanup
    window.addEventListener("keydown", handleKeydown)
  },
  unmounted(el) {
    window.removeEventListener("keydown", el.__handleKeydown__)
    delete el.__handleKeydown__
  },
}
```

I also replaced the current implementation of the shortcut search in the big search with the directive solution --> see [here](https://github.com/digitalservicebund/ris-backend-service/pull/2446/files#diff-4d0b0fe2a21fe00ac9c333ac2e498c9037d26d8401cfd9de27ff8b8d97136144)

Most of the code changes are due to adding the directive into the frontend tests and adding tests themselves :) 