### PR TITLE
Reset document number count on each year

### DIFF
--- a/backend/src/main/java/de/bund/digitalservice/ris/caselaw/adapter/DatabaseDocumentNumberGeneratorService.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/caselaw/adapter/DatabaseDocumentNumberGeneratorService.java
@@ -79,13 +79,7 @@ public class DatabaseDocumentNumberGeneratorService implements DocumentNumberSer
     if (recycledId != null) return recycledId;
 
     DocumentNumberDTO documentNumberDTO =
-        repository
-            .findById(documentationOfficeAbbreviation)
-            .orElse(
-                DocumentNumberDTO.builder()
-                    .documentationOfficeAbbreviation(documentationOfficeAbbreviation)
-                    .lastNumber(0)
-                    .build());
+        getOrCreateDocumentNumberDTO(documentationOfficeAbbreviation);
 
     String documentNumber =
         DocumentNumberFormatter.builder()
@@ -100,6 +94,26 @@ public class DatabaseDocumentNumberGeneratorService implements DocumentNumberSer
     assertNotExists(documentNumber);
 
     return documentNumber;
+  }
+
+  /**
+   * Retrieves an existing document number entry for the given documentation office abbreviation and
+   * year, or creates a new document number entry if none exists.
+   *
+   * @param documentationOfficeAbbreviation desired court abbreviation by office
+   * @return A {@link DocumentNumberDTO} containing the latest doc number count
+   */
+  public DocumentNumberDTO getOrCreateDocumentNumberDTO(
+      @NotEmpty String documentationOfficeAbbreviation) {
+    return repository
+        .findByDocumentationOfficeAbbreviationAndYear(
+            documentationOfficeAbbreviation, DateUtil.getYear())
+        .orElse(
+            DocumentNumberDTO.builder()
+                .documentationOfficeAbbreviation(documentationOfficeAbbreviation)
+                .lastNumber(0)
+                .year(DateUtil.getYear())
+                .build());
   }
 
   /**

--- a/backend/src/main/java/de/bund/digitalservice/ris/caselaw/adapter/database/jpa/DatabaseDocumentNumberRepository.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/caselaw/adapter/database/jpa/DatabaseDocumentNumberRepository.java
@@ -1,15 +1,13 @@
 package de.bund.digitalservice.ris.caselaw.adapter.database.jpa;
 
-import jakarta.persistence.LockModeType;
+import java.time.Year;
 import java.util.Optional;
-import org.jetbrains.annotations.NotNull;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Lock;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface DatabaseDocumentNumberRepository extends JpaRepository<DocumentNumberDTO, String> {
-  @NotNull
-  @Lock(LockModeType.PESSIMISTIC_WRITE)
-  Optional<DocumentNumberDTO> findById(@NotNull String id);
+
+  Optional<DocumentNumberDTO> findByDocumentationOfficeAbbreviationAndYear(
+      String documentationOfficeAbbreviation, Year year);
 }

--- a/backend/src/main/java/de/bund/digitalservice/ris/caselaw/adapter/database/jpa/DatabaseDocumentNumberRepository.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/caselaw/adapter/database/jpa/DatabaseDocumentNumberRepository.java
@@ -1,13 +1,19 @@
 package de.bund.digitalservice.ris.caselaw.adapter.database.jpa;
 
+import jakarta.persistence.LockModeType;
+import jakarta.validation.constraints.NotBlank;
 import java.time.Year;
 import java.util.Optional;
+import org.jetbrains.annotations.NotNull;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface DatabaseDocumentNumberRepository extends JpaRepository<DocumentNumberDTO, String> {
 
+  @NotNull
+  @Lock(LockModeType.PESSIMISTIC_WRITE)
   Optional<DocumentNumberDTO> findByDocumentationOfficeAbbreviationAndYear(
-      String documentationOfficeAbbreviation, Year year);
+      @NotBlank String documentationOfficeAbbreviation, @NotNull Year year);
 }

--- a/backend/src/main/java/de/bund/digitalservice/ris/caselaw/adapter/database/jpa/DocumentNumberDTO.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/caselaw/adapter/database/jpa/DocumentNumberDTO.java
@@ -2,13 +2,17 @@ package de.bund.digitalservice.ris.caselaw.adapter.database.jpa;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotEmpty;
+import java.time.Year;
+import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.jetbrains.annotations.NotNull;
 
 @Data
 @Builder
@@ -18,13 +22,18 @@ import lombok.NoArgsConstructor;
 @Table(name = "document_number", schema = "public")
 public class DocumentNumberDTO {
 
-  @Id
+  @Id @GeneratedValue private UUID id;
+
   @Column(name = "documentation_office_abbreviation")
   @NotEmpty
   private String documentationOfficeAbbreviation;
 
   @Column(name = "last_number")
   private int lastNumber;
+
+  @Column(name = "year")
+  @NotNull
+  private Year year;
 
   public Integer increaseLastNumber() {
     this.lastNumber = lastNumber + 1;

--- a/backend/src/main/resources/db-scripts/migration/V1.11__add_id_to_document_number.sql
+++ b/backend/src/main/resources/db-scripts/migration/V1.11__add_id_to_document_number.sql
@@ -1,0 +1,13 @@
+-- Adding unique id to document number table
+ALTER TABLE document_number
+    ADD COLUMN id UUID NOT NULL DEFAULT gen_random_uuid();
+
+-- Drop the existing primary key constraint directing to documentation_office_abbreviation
+ALTER TABLE document_number
+DROP CONSTRAINT document_number_pkey;
+
+-- Add a new primary key constraint on id column
+ALTER TABLE document_number
+    ADD CONSTRAINT document_number_pkey PRIMARY KEY (id);
+
+

--- a/backend/src/main/resources/db-scripts/migration/V1.12__add_year_to_document_number.sql
+++ b/backend/src/main/resources/db-scripts/migration/V1.12__add_year_to_document_number.sql
@@ -1,0 +1,13 @@
+-- Adding year to document number count
+ALTER TABLE IF EXISTS document_number
+    ADD year INTEGER;
+
+-- Adding previous year to document number count
+UPDATE document_number SET year = 2024 WHERE year IS NULL;
+
+-- Setting required year for upcoming entries
+ALTER TABLE document_number ALTER COLUMN year SET NOT NULL;
+
+-- Create a combined index on 'documentation_office_abbreviation' and 'year'
+CREATE INDEX idx_documentation_office_abbreviation_year
+    ON document_number (documentation_office_abbreviation, year);

--- a/backend/src/test/java/de/bund/digitalservice/ris/caselaw/integration/tests/DocumentationUnitIntegrationTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/caselaw/integration/tests/DocumentationUnitIntegrationTest.java
@@ -54,6 +54,7 @@ import de.bund.digitalservice.ris.caselaw.domain.AttachmentService;
 import de.bund.digitalservice.ris.caselaw.domain.AuthService;
 import de.bund.digitalservice.ris.caselaw.domain.ContentRelatedIndexing;
 import de.bund.digitalservice.ris.caselaw.domain.CoreData;
+import de.bund.digitalservice.ris.caselaw.domain.DateUtil;
 import de.bund.digitalservice.ris.caselaw.domain.DocumentationOffice;
 import de.bund.digitalservice.ris.caselaw.domain.DocumentationUnit;
 import de.bund.digitalservice.ris.caselaw.domain.DocumentationUnitCreationParameters;
@@ -77,8 +78,6 @@ import de.bund.digitalservice.ris.caselaw.domain.mapper.PatchMapperService;
 import de.bund.digitalservice.ris.caselaw.webtestclient.RisWebTestClient;
 import java.net.URI;
 import java.time.LocalDate;
-import java.time.Year;
-import java.time.temporal.ChronoField;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -1036,18 +1035,20 @@ class DocumentationUnitIntegrationTest {
         DeletedDocumentationUnitDTO.builder()
             .abbreviation("DS")
             .documentNumber("ZZRE202400001")
-            .year(Year.of(LocalDate.now().get(ChronoField.YEAR)))
+            .year(DateUtil.getYear())
             .build();
     deletedDocumentationIdsRepository.save(deletedDocumentationUnitDTO);
 
     when(documentNumberPatternConfig.getDocumentNumberPatterns())
         .thenReturn(Map.of("DS", "ZZREYYYY*****"));
-    when(databaseDocumentNumberRepository.findById("DS"))
+    when(databaseDocumentNumberRepository.findByDocumentationOfficeAbbreviationAndYear(
+            "DS", DateUtil.getYear()))
         .thenReturn(
             Optional.of(
                 DocumentNumberDTO.builder()
                     .documentationOfficeAbbreviation("DS")
                     .lastNumber(1)
+                    .year(DateUtil.getYear())
                     .build()));
 
     risWebTestClient


### PR DESCRIPTION
RISDEV-6004

* Adding year to document number table
* Dropping old constraint on abbreviation and update on id
* Adding combined index for year and doc office
* Backfilling 2024 for former year entries
* Retrieve document number by both doc office and year
* Extracting getOrCreateDocumentNumberDTO to method
* Adding tests