### PR TITLE
Fix decision/doc_unit table ref for dup_check

### DIFF
--- a/backend/src/main/java/de/bund/digitalservice/ris/caselaw/adapter/DatabaseDuplicateCheckService.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/caselaw/adapter/DatabaseDuplicateCheckService.java
@@ -57,8 +57,7 @@ public class DatabaseDuplicateCheckService implements DuplicateCheckService {
       }
 
     } catch (Exception e) {
-      var errorMessage = String.format("Could not check duplicates for doc unit %s", docNumber);
-      log.error(errorMessage, e);
+      log.error("Could not check duplicates for doc unit {}", docNumber, e);
     }
   }
 
@@ -68,7 +67,11 @@ public class DatabaseDuplicateCheckService implements DuplicateCheckService {
   @Transactional
   @Override
   public void checkAllDuplicates() {
-    this.duplicateRelationService.updateAllDuplicates();
+    try {
+      this.duplicateRelationService.updateAllDuplicates();
+    } catch (Exception e) {
+      log.error("Error while updating duplicate relations", e);
+    }
   }
 
   private List<DocumentationUnitIdDuplicateCheckDTO> findPotentialDuplicates(

--- a/backend/src/main/java/de/bund/digitalservice/ris/caselaw/adapter/database/jpa/DuplicateRelationRepository.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/caselaw/adapter/database/jpa/DuplicateRelationRepository.java
@@ -192,8 +192,8 @@ SELECT drel.id_a, drel.id_b,
 FROM duplicate_relations_view drel
          LEFT JOIN incremental_migration.duplicate_relation ON drel.id_a = duplicate_relation.documentation_unit_id1 AND
                                                                drel.id_b = duplicate_relation.documentation_unit_id2
-         LEFT JOIN incremental_migration.decision d1 ON drel.id_a = d1.id
-         LEFT JOIN incremental_migration.decision d2 ON drel.id_b = d2.id
+         LEFT JOIN incremental_migration.documentation_unit d1 ON drel.id_a = d1.id
+         LEFT JOIN incremental_migration.documentation_unit d2 ON drel.id_b = d2.id
 WHERE duplicate_relation.documentation_unit_id1 IS NULL;
 """,
       nativeQuery = true)


### PR DESCRIPTION
RISDEV-88
When decision was extracted from doc unit, the duplicate_check attribute was first moved to decision and then back to doc unit. During the second refactoring, the table was not adjusted correctly.