### PR TITLE
Unassign test procedures in seeding script

### DIFF
--- a/backend/src/main/resources/db-scripts/seed/R__seeding_testdata.sql
+++ b/backend/src/main/resources/db-scripts/seed/R__seeding_testdata.sql
@@ -20,6 +20,13 @@ where
 
 COMMIT;
 
+-- Unassign other doc units from test procedures, so that they can be deleted.
+UPDATE incremental_migration.decision
+SET current_procedure_id = NULL
+WHERE current_procedure_id IN ((SELECT id
+                                from incremental_migration.procedure
+                                where name LIKE 'test\_%'));
+
 -- Delete test-related records from documentation_unit_procedure
 delete from
     incremental_migration.documentation_unit_procedure


### PR DESCRIPTION
RISDEV-0000
The test procedures from the seeding script can only be deleted, if no decisions are assigned to them.