### PR TITLE
Ignore duplicates when jDV dup status is set

### DIFF
--- a/backend/src/main/java/de/bund/digitalservice/ris/caselaw/adapter/DocumentationUnitController.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/caselaw/adapter/DocumentationUnitController.java
@@ -254,8 +254,9 @@ public class DocumentationUnitController {
     }
 
     try {
-      Documentable documentable = service.getByDocumentNumberWithUser(documentNumber, oidcUser);
+      // Duplicate check must happen before getting the doc unit, otherwise new ones won't be shown
       checkDuplicates(documentNumber);
+      Documentable documentable = service.getByDocumentNumberWithUser(documentNumber, oidcUser);
       return ResponseEntity.ok((DocumentationUnit) documentable);
 
     } catch (DocumentationUnitNotExistsException e) {

--- a/backend/src/main/java/de/bund/digitalservice/ris/caselaw/adapter/database/jpa/DatabaseDuplicateCheckRepository.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/caselaw/adapter/database/jpa/DatabaseDuplicateCheckRepository.java
@@ -26,8 +26,9 @@ public interface DatabaseDuplicateCheckRepository
         HAVING COUNT(*) <= 50
     )
 
-    SELECT documentationUnit.id, documentationUnit.duplicate_check AS isJdvDuplicateCheckActive
+    SELECT documentationUnit.id, documentationUnit.duplicate_check AS isJdvDuplicateCheckActive, status.publication_status AS status
     FROM incremental_migration.documentation_unit documentationUnit
+      LEFT JOIN incremental_migration.status status ON status.id = documentationUnit.current_status_id
       JOIN incremental_migration.file_number fileNumber
         ON documentationUnit.id = fileNumber.documentation_unit_id
       INNER JOIN incremental_migration.decision decision
@@ -37,8 +38,9 @@ public interface DatabaseDuplicateCheckRepository
 
     UNION
 
-    SELECT documentationUnit.id, documentationUnit.duplicate_check AS isJdvDuplicateCheckActive
+    SELECT documentationUnit.id, documentationUnit.duplicate_check AS isJdvDuplicateCheckActive, status.publication_status AS status
     FROM incremental_migration.documentation_unit documentationUnit
+      LEFT JOIN incremental_migration.status status ON status.id = documentationUnit.current_status_id
       JOIN incremental_migration.file_number fileNumber
         ON documentationUnit.id = fileNumber.documentation_unit_id
       JOIN incremental_migration.deviating_date deviatingDate
@@ -50,8 +52,9 @@ public interface DatabaseDuplicateCheckRepository
 
     UNION
 
-    SELECT documentationUnit.id, documentationUnit.duplicate_check AS isJdvDuplicateCheckActive
+    SELECT documentationUnit.id, documentationUnit.duplicate_check AS isJdvDuplicateCheckActive, status.publication_status AS status
     FROM incremental_migration.documentation_unit documentationUnit
+      LEFT JOIN incremental_migration.status status ON status.id = documentationUnit.current_status_id
       JOIN incremental_migration.deviating_file_number deviatingFileNumber
         ON documentationUnit.id = deviatingFileNumber.documentation_unit_id
       INNER JOIN incremental_migration.decision decision
@@ -61,8 +64,9 @@ public interface DatabaseDuplicateCheckRepository
 
     UNION
 
-    SELECT documentationUnit.id, documentationUnit.duplicate_check AS isJdvDuplicateCheckActive
+    SELECT documentationUnit.id, documentationUnit.duplicate_check AS isJdvDuplicateCheckActive, status.publication_status AS status
     FROM incremental_migration.documentation_unit documentationUnit
+      LEFT JOIN incremental_migration.status status ON status.id = documentationUnit.current_status_id
       JOIN incremental_migration.deviating_file_number deviatingFileNumber
         ON documentationUnit.id = deviatingFileNumber.documentation_unit_id
       JOIN incremental_migration.deviating_date deviatingDate
@@ -74,8 +78,9 @@ public interface DatabaseDuplicateCheckRepository
 
     UNION
 
-    SELECT documentationUnit.id, documentationUnit.duplicate_check AS isJdvDuplicateCheckActive
+    SELECT documentationUnit.id, documentationUnit.duplicate_check AS isJdvDuplicateCheckActive, status.publication_status AS status
     FROM incremental_migration.documentation_unit documentationUnit
+      LEFT JOIN incremental_migration.status status ON status.id = documentationUnit.current_status_id
       JOIN incremental_migration.file_number fileNumber
         ON documentationUnit.id = fileNumber.documentation_unit_id
       JOIN incremental_migration.court court
@@ -90,8 +95,9 @@ public interface DatabaseDuplicateCheckRepository
 
     UNION
 
-    SELECT documentationUnit.id, documentationUnit.duplicate_check AS isJdvDuplicateCheckActive
+    SELECT documentationUnit.id, documentationUnit.duplicate_check AS isJdvDuplicateCheckActive, status.publication_status AS status
     FROM incremental_migration.documentation_unit documentationUnit
+      LEFT JOIN incremental_migration.status status ON status.id = documentationUnit.current_status_id
       JOIN incremental_migration.deviating_file_number deviatingFileNumber
         ON documentationUnit.id = deviatingFileNumber.documentation_unit_id
       JOIN incremental_migration.court court
@@ -106,8 +112,9 @@ public interface DatabaseDuplicateCheckRepository
 
     UNION
 
-    SELECT documentationUnit.id, documentationUnit.duplicate_check AS isJdvDuplicateCheckActive
+    SELECT documentationUnit.id, documentationUnit.duplicate_check AS isJdvDuplicateCheckActive, status.publication_status AS status
     FROM incremental_migration.documentation_unit documentationUnit
+      LEFT JOIN incremental_migration.status status ON status.id = documentationUnit.current_status_id
       JOIN incremental_migration.file_number fileNumber
         ON documentationUnit.id = fileNumber.documentation_unit_id
       JOIN incremental_migration.deviating_court deviatingCourt
@@ -122,8 +129,9 @@ public interface DatabaseDuplicateCheckRepository
 
     UNION
 
-    SELECT documentationUnit.id, documentationUnit.duplicate_check AS isJdvDuplicateCheckActive
+    SELECT documentationUnit.id, documentationUnit.duplicate_check AS isJdvDuplicateCheckActive, status.publication_status AS status
     FROM incremental_migration.documentation_unit documentationUnit
+      LEFT JOIN incremental_migration.status status ON status.id = documentationUnit.current_status_id
       JOIN incremental_migration.deviating_file_number deviatingFileNumber
         ON documentationUnit.id = deviatingFileNumber.documentation_unit_id
       JOIN incremental_migration.deviating_court deviatingCourt
@@ -138,16 +146,18 @@ public interface DatabaseDuplicateCheckRepository
 
     UNION
 
-    SELECT documentationUnit.id, documentationUnit.duplicate_check AS isJdvDuplicateCheckActive
+    SELECT documentationUnit.id, documentationUnit.duplicate_check AS isJdvDuplicateCheckActive, status.publication_status AS status
     FROM incremental_migration.documentation_unit documentationUnit
+    LEFT JOIN incremental_migration.status status ON status.id = documentationUnit.current_status_id
     INNER JOIN incremental_migration.decision decision
       ON decision.id = documentationUnit.id
     WHERE upper(decision.ecli) IN (:allEclis) AND decision.ecli != ''
 
     UNION
 
-    SELECT documentationUnit.id, documentationUnit.duplicate_check AS isJdvDuplicateCheckActive
+    SELECT documentationUnit.id, documentationUnit.duplicate_check AS isJdvDuplicateCheckActive, status.publication_status AS status
     FROM incremental_migration.documentation_unit documentationUnit
+    LEFT JOIN incremental_migration.status status ON status.id = documentationUnit.current_status_id
     INNER JOIN incremental_migration.decision decision
       ON decision.id = documentationUnit.id
     JOIN incremental_migration.deviating_ecli deviatingEcli

--- a/backend/src/main/java/de/bund/digitalservice/ris/caselaw/adapter/database/jpa/DocumentationUnitIdDuplicateCheckDTO.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/caselaw/adapter/database/jpa/DocumentationUnitIdDuplicateCheckDTO.java
@@ -1,5 +1,6 @@
 package de.bund.digitalservice.ris.caselaw.adapter.database.jpa;
 
+import de.bund.digitalservice.ris.caselaw.domain.PublicationStatus;
 import java.util.UUID;
 
 /**
@@ -10,4 +11,6 @@ public interface DocumentationUnitIdDuplicateCheckDTO {
   UUID getId();
 
   Boolean getIsJdvDuplicateCheckActive();
+
+  PublicationStatus getStatus();
 }

--- a/backend/src/test/java/de/bund/digitalservice/ris/caselaw/integration/tests/DuplicateCheckFullIntegrationTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/caselaw/integration/tests/DuplicateCheckFullIntegrationTest.java
@@ -399,6 +399,92 @@ class DuplicateCheckFullIntegrationTest {
 
     @Test
     void
+        checkDuplicates_withoutExistingDuplicatesAndIsJdvDuplicateCheckActiveTrueAndLockedStatus_shouldCreateNewDuplicateWithIgnoredStatus()
+            throws DocumentationUnitNotExistsException {
+      // Arrange
+      var docUnitToBeChecked =
+          generateNewDocumentationUnit(
+              docOffice,
+              Optional.of(
+                  CreationParameters.builder()
+                      .documentNumber("DocumentNumb1")
+                      .decisionDate(LocalDate.of(2020, 12, 1))
+                      .fileNumbers(List.of("AZ-123"))
+                      .publicationStatus(PublicationStatus.LOCKED)
+                      .build()));
+
+      var docUnitDuplicateDTO =
+          generateNewDocumentationUnit(
+              docOffice,
+              Optional.of(
+                  CreationParameters.builder()
+                      .documentNumber("DocumentNumb2")
+                      .decisionDate(LocalDate.of(2020, 12, 1))
+                      .isJdvDuplicateCheckActive(true)
+                      .fileNumbers(List.of("AZ-123"))
+                      .build()));
+
+      assertThat(duplicateRelationRepository.findAll()).isEmpty();
+
+      // Act
+      duplicateCheckService.checkDuplicates(docUnitToBeChecked.getDocumentNumber());
+
+      var foundDocUnit =
+          (DocumentationUnit) documentationUnitService.getByUuid(docUnitToBeChecked.getId());
+
+      // Assert
+      assertThat(duplicateRelationRepository.findAll()).hasSize(1);
+      DuplicateRelation duplicate =
+          foundDocUnit.managementData().duplicateRelations().stream().findFirst().get();
+      assertThat(duplicate.documentNumber()).isEqualTo(docUnitDuplicateDTO.getDocumentNumber());
+      assertThat(duplicate.status()).isEqualTo(DuplicateRelationStatus.IGNORED);
+    }
+
+    @Test
+    void
+        checkDuplicates_withoutExistingDuplicatesAndIsJdvDuplicateCheckActiveTrueAndDuplicatedStatus_shouldCreateNewDuplicateWithIgnoredStatus()
+            throws DocumentationUnitNotExistsException {
+      // Arrange
+      var docUnitToBeChecked =
+          generateNewDocumentationUnit(
+              docOffice,
+              Optional.of(
+                  CreationParameters.builder()
+                      .documentNumber("DocumentNumb1")
+                      .decisionDate(LocalDate.of(2020, 12, 1))
+                      .isJdvDuplicateCheckActive(true)
+                      .fileNumbers(List.of("AZ-123"))
+                      .build()));
+
+      var docUnitDuplicateDTO =
+          generateNewDocumentationUnit(
+              docOffice,
+              Optional.of(
+                  CreationParameters.builder()
+                      .documentNumber("DocumentNumb2")
+                      .decisionDate(LocalDate.of(2020, 12, 1))
+                      .publicationStatus(PublicationStatus.DUPLICATED)
+                      .fileNumbers(List.of("AZ-123"))
+                      .build()));
+
+      assertThat(duplicateRelationRepository.findAll()).isEmpty();
+
+      // Act
+      duplicateCheckService.checkDuplicates(docUnitToBeChecked.getDocumentNumber());
+
+      var foundDocUnit =
+          (DocumentationUnit) documentationUnitService.getByUuid(docUnitToBeChecked.getId());
+
+      // Assert
+      assertThat(duplicateRelationRepository.findAll()).hasSize(1);
+      DuplicateRelation duplicate =
+          foundDocUnit.managementData().duplicateRelations().stream().findFirst().get();
+      assertThat(duplicate.documentNumber()).isEqualTo(docUnitDuplicateDTO.getDocumentNumber());
+      assertThat(duplicate.status()).isEqualTo(DuplicateRelationStatus.IGNORED);
+    }
+
+    @Test
+    void
         checkDuplicates_withoutExistingDuplicatesAndIsJdvDuplicateCheckActiveFalse_shouldCreateNewDuplicateWithIgnoredStatus()
             throws DocumentationUnitNotExistsException {
       // Arrange

--- a/backend/src/test/java/de/bund/digitalservice/ris/caselaw/integration/tests/DuplicateCheckIntegrationTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/caselaw/integration/tests/DuplicateCheckIntegrationTest.java
@@ -203,12 +203,12 @@ class DuplicateCheckIntegrationTest {
       // Act
       duplicateCheckService.checkDuplicates(docUnitWithoutFileNumbers.getDocumentNumber());
 
-      var foundDocUnit = documentationUnitService.getByUuid(docUnitWithoutFileNumbers.getId());
+      var foundDocUnit =
+          (DocumentationUnit) documentationUnitService.getByUuid(docUnitWithoutFileNumbers.getId());
 
       // Assert
       assertThat(duplicateRelationRepository.findAll()).isEmpty();
-      assertThat(((DocumentationUnit) foundDocUnit).managementData().duplicateRelations())
-          .isEmpty();
+      assertThat(foundDocUnit.managementData().duplicateRelations()).isEmpty();
     }
 
     @Test
@@ -225,12 +225,12 @@ class DuplicateCheckIntegrationTest {
       // Act
       duplicateCheckService.checkDuplicates(docUnitWithoutFileNumbers.getDocumentNumber());
 
-      var foundDocUnit = documentationUnitService.getByUuid(docUnitWithoutFileNumbers.getId());
+      var foundDocUnit =
+          (DocumentationUnit) documentationUnitService.getByUuid(docUnitWithoutFileNumbers.getId());
 
       // Assert
       assertThat(duplicateRelationRepository.findAll()).isEmpty();
-      assertThat(((DocumentationUnit) foundDocUnit).managementData().duplicateRelations())
-          .isEmpty();
+      assertThat(foundDocUnit.managementData().duplicateRelations()).isEmpty();
     }
 
     @Test
@@ -299,13 +299,12 @@ class DuplicateCheckIntegrationTest {
       // Act
       duplicateCheckService.checkDuplicates(docUnitToBeChecked.getDocumentNumber());
 
-      var foundDocUnit = documentationUnitService.getByUuid(docUnitToBeChecked.getId());
+      var foundDocUnit =
+          (DocumentationUnit) documentationUnitService.getByUuid(docUnitToBeChecked.getId());
 
       // Assert
       assertThat(duplicateRelationRepository.findAll()).hasSize(1);
-      DuplicateRelation duplicate =
-          ((DocumentationUnit) foundDocUnit)
-              .managementData().duplicateRelations().stream().findFirst().get();
+      DuplicateRelation duplicate = foundDocUnit.managementData().duplicateRelations().getFirst();
       assertThat(duplicate.documentNumber()).isEqualTo(docUnitDuplicateDTO.getDocumentNumber());
       assertThat(duplicate.status()).isEqualTo(DuplicateRelationStatus.PENDING);
     }
@@ -339,13 +338,12 @@ class DuplicateCheckIntegrationTest {
       // Act
       duplicateCheckService.checkDuplicates(docUnitToBeChecked.getDocumentNumber());
 
-      var foundDocUnit = documentationUnitService.getByUuid(docUnitToBeChecked.getId());
+      var foundDocUnit =
+          (DocumentationUnit) documentationUnitService.getByUuid(docUnitToBeChecked.getId());
 
       // Assert
       assertThat(duplicateRelationRepository.findAll()).hasSize(1);
-      DuplicateRelation duplicate =
-          ((DocumentationUnit) foundDocUnit)
-              .managementData().duplicateRelations().stream().findFirst().get();
+      DuplicateRelation duplicate = foundDocUnit.managementData().duplicateRelations().getFirst();
       assertThat(duplicate.documentNumber()).isEqualTo(docUnitDuplicateDTO.getDocumentNumber());
       assertThat(duplicate.status()).isEqualTo(DuplicateRelationStatus.PENDING);
     }
@@ -381,15 +379,98 @@ class DuplicateCheckIntegrationTest {
       // Act
       duplicateCheckService.checkDuplicates(docUnitToBeChecked.getDocumentNumber());
 
-      var foundDocUnit = documentationUnitService.getByUuid(docUnitToBeChecked.getId());
+      var foundDocUnit =
+          (DocumentationUnit) documentationUnitService.getByUuid(docUnitToBeChecked.getId());
 
       // Assert
       assertThat(duplicateRelationRepository.findAll()).hasSize(1);
-      DuplicateRelation duplicate =
-          ((DocumentationUnit) foundDocUnit)
-              .managementData().duplicateRelations().stream().findFirst().get();
+      DuplicateRelation duplicate = foundDocUnit.managementData().duplicateRelations().getFirst();
       assertThat(duplicate.documentNumber()).isEqualTo(docUnitDuplicateDTO.getDocumentNumber());
       assertThat(duplicate.status()).isEqualTo(DuplicateRelationStatus.PENDING);
+    }
+
+    @Test
+    void
+        checkDuplicates_withoutExistingDuplicatesAndIsJdvDuplicateCheckActiveTrueAndLockedStatus_shouldCreateNewDuplicateWithIgnoredStatus()
+            throws DocumentationUnitNotExistsException {
+      // Arrange
+      var docUnitToBeChecked =
+          generateNewDocumentationUnit(
+              docOffice,
+              Optional.of(
+                  CreationParameters.builder()
+                      .documentNumber("DocumentNumb1")
+                      .decisionDate(LocalDate.of(2020, 12, 1))
+                      .isJdvDuplicateCheckActive(true)
+                      .fileNumbers(List.of("AZ-123"))
+                      .build()));
+
+      var docUnitDuplicateDTO =
+          generateNewDocumentationUnit(
+              docOffice,
+              Optional.of(
+                  CreationParameters.builder()
+                      .documentNumber("DocumentNumb2")
+                      .decisionDate(LocalDate.of(2020, 12, 1))
+                      .fileNumbers(List.of("AZ-123"))
+                      .publicationStatus(PublicationStatus.LOCKED)
+                      .build()));
+
+      assertThat(duplicateRelationRepository.findAll()).isEmpty();
+
+      // Act
+      duplicateCheckService.checkDuplicates(docUnitToBeChecked.getDocumentNumber());
+
+      var foundDocUnit =
+          (DocumentationUnit) documentationUnitService.getByUuid(docUnitToBeChecked.getId());
+
+      // Assert
+      assertThat(duplicateRelationRepository.findAll()).hasSize(1);
+      DuplicateRelation duplicate = foundDocUnit.managementData().duplicateRelations().getFirst();
+      assertThat(duplicate.documentNumber()).isEqualTo(docUnitDuplicateDTO.getDocumentNumber());
+      assertThat(duplicate.status()).isEqualTo(DuplicateRelationStatus.IGNORED);
+    }
+
+    @Test
+    void
+        checkDuplicates_withoutExistingDuplicatesAndIsJdvDuplicateCheckActiveTrueAndDuplicatedStatus_shouldCreateNewDuplicateWithIgnoredStatus()
+            throws DocumentationUnitNotExistsException {
+      // Arrange
+      var docUnitToBeChecked =
+          generateNewDocumentationUnit(
+              docOffice,
+              Optional.of(
+                  CreationParameters.builder()
+                      .documentNumber("DocumentNumb1")
+                      .decisionDate(LocalDate.of(2020, 12, 1))
+                      .fileNumbers(List.of("AZ-123"))
+                      .publicationStatus(PublicationStatus.DUPLICATED)
+                      .build()));
+
+      var docUnitDuplicateDTO =
+          generateNewDocumentationUnit(
+              docOffice,
+              Optional.of(
+                  CreationParameters.builder()
+                      .documentNumber("DocumentNumb2")
+                      .decisionDate(LocalDate.of(2020, 12, 1))
+                      .isJdvDuplicateCheckActive(true)
+                      .fileNumbers(List.of("AZ-123"))
+                      .build()));
+
+      assertThat(duplicateRelationRepository.findAll()).isEmpty();
+
+      // Act
+      duplicateCheckService.checkDuplicates(docUnitToBeChecked.getDocumentNumber());
+
+      var foundDocUnit =
+          (DocumentationUnit) documentationUnitService.getByUuid(docUnitToBeChecked.getId());
+
+      // Assert
+      assertThat(duplicateRelationRepository.findAll()).hasSize(1);
+      DuplicateRelation duplicate = foundDocUnit.managementData().duplicateRelations().getFirst();
+      assertThat(duplicate.documentNumber()).isEqualTo(docUnitDuplicateDTO.getDocumentNumber());
+      assertThat(duplicate.status()).isEqualTo(DuplicateRelationStatus.IGNORED);
     }
 
     @Test
@@ -423,13 +504,12 @@ class DuplicateCheckIntegrationTest {
       // Act
       duplicateCheckService.checkDuplicates(docUnitToBeChecked.getDocumentNumber());
 
-      var foundDocUnit = documentationUnitService.getByUuid(docUnitToBeChecked.getId());
+      var foundDocUnit =
+          (DocumentationUnit) documentationUnitService.getByUuid(docUnitToBeChecked.getId());
 
       // Assert
       assertThat(duplicateRelationRepository.findAll()).hasSize(1);
-      DuplicateRelation duplicate =
-          ((DocumentationUnit) foundDocUnit)
-              .managementData().duplicateRelations().stream().findFirst().get();
+      DuplicateRelation duplicate = foundDocUnit.managementData().duplicateRelations().getFirst();
       assertThat(duplicate.documentNumber()).isEqualTo(docUnitDuplicateDTO.getDocumentNumber());
       assertThat(duplicate.status()).isEqualTo(DuplicateRelationStatus.IGNORED);
     }
@@ -464,10 +544,11 @@ class DuplicateCheckIntegrationTest {
       // Create duplicate with pending status
       duplicateCheckService.checkDuplicates(docUnitToBeChecked.getDocumentNumber());
       assertThat(
-              ((DocumentationUnit)
-                      ((DocumentationUnit)
-                          documentationUnitService.getByUuid(docUnitToBeChecked.getId())))
-                  .managementData().duplicateRelations().stream().findFirst().get().status())
+              ((DocumentationUnit) documentationUnitService.getByUuid(docUnitToBeChecked.getId()))
+                  .managementData()
+                  .duplicateRelations()
+                  .getFirst()
+                  .status())
           .isEqualTo(DuplicateRelationStatus.PENDING);
 
       // change isJdvDuplicateCheckActive from null to false
@@ -476,13 +557,12 @@ class DuplicateCheckIntegrationTest {
 
       // Act
       duplicateCheckService.checkDuplicates(docUnitToBeChecked.getDocumentNumber());
-      var foundDocUnit = documentationUnitService.getByUuid(docUnitToBeChecked.getId());
+      var foundDocUnit =
+          (DocumentationUnit) documentationUnitService.getByUuid(docUnitToBeChecked.getId());
 
       // Assert
       assertThat(duplicateRelationRepository.findAll()).hasSize(1);
-      DuplicateRelation duplicate =
-          ((DocumentationUnit) foundDocUnit)
-              .managementData().duplicateRelations().stream().findFirst().get();
+      DuplicateRelation duplicate = foundDocUnit.managementData().duplicateRelations().getFirst();
       assertThat(duplicate.documentNumber()).isEqualTo(duplicateDTO.getDocumentNumber());
       assertThat(duplicate.status()).isEqualTo(DuplicateRelationStatus.IGNORED);
     }
@@ -524,7 +604,10 @@ class DuplicateCheckIntegrationTest {
       duplicateCheckService.checkDuplicates(docUnitToBeChecked.getDocumentNumber());
       assertThat(
               ((DocumentationUnit) documentationUnitService.getByUuid(docUnitToBeChecked.getId()))
-                  .managementData().duplicateRelations().stream().findFirst().get().status())
+                  .managementData()
+                  .duplicateRelations()
+                  .getFirst()
+                  .status())
           .isEqualTo(DuplicateRelationStatus.PENDING);
       assertThat(duplicateRelationRepository.findAll()).hasSize(2);
 
@@ -534,16 +617,12 @@ class DuplicateCheckIntegrationTest {
 
       // Act
       duplicateCheckService.checkDuplicates(docUnitToBeChecked.getDocumentNumber());
-      var foundDocUnit = documentationUnitService.getByUuid(docUnitToBeChecked.getId());
+      var foundDocUnit =
+          (DocumentationUnit) documentationUnitService.getByUuid(docUnitToBeChecked.getId());
 
       // Assert
       assertThat(duplicateRelationRepository.findAll()).hasSize(1);
-      assertThat(
-              ((DocumentationUnit) foundDocUnit)
-                  .managementData().duplicateRelations().stream()
-                      .findFirst()
-                      .get()
-                      .documentNumber())
+      assertThat(foundDocUnit.managementData().duplicateRelations().getFirst().documentNumber())
           .isEqualTo("DocumentNumb2");
     }
 
@@ -638,6 +717,53 @@ class DuplicateCheckIntegrationTest {
     }
 
     @Test
+    void checkDuplicates_whenRequestingDocUnit_shouldIncludeNewWarningsInResponse() {
+      // Arrange
+      var docUnitToBeChecked =
+          generateNewDocumentationUnit(
+              docOffice,
+              Optional.of(
+                  CreationParameters.builder()
+                      .documentNumber("DocumentNumb1")
+                      .decisionDate(LocalDate.of(2020, 12, 1))
+                      .fileNumbers(List.of("AZ-123"))
+                      .build()));
+
+      var docUnitDuplicateDTO =
+          generateNewDocumentationUnit(
+              docOffice,
+              Optional.of(
+                  CreationParameters.builder()
+                      .documentNumber("DocumentNumb2")
+                      .decisionDate(LocalDate.of(2020, 12, 1))
+                      .fileNumbers(List.of("AZ-123"))
+                      .build()));
+
+      assertThat(duplicateRelationRepository.findAll()).isEmpty();
+
+      // Act: GET-requesting a doc unit should trigger check
+      var docUnitResponse =
+          risWebTestClient
+              .withDefaultLogin()
+              .get()
+              .uri("/api/v1/caselaw/documentunits/" + docUnitToBeChecked.getDocumentNumber())
+              .exchange()
+              .expectStatus()
+              .isOk()
+              .expectBody(DocumentationUnit.class)
+              .returnResult()
+              .getResponseBody();
+
+      // Assert: GET response should include duplicate relations
+      assertThat(duplicateRelationRepository.findAll()).hasSize(1);
+      List<DuplicateRelation> duplicates = docUnitResponse.managementData().duplicateRelations();
+      assertThat(duplicates).hasSize(1);
+      assertThat(duplicates.getFirst().documentNumber())
+          .isEqualTo(docUnitDuplicateDTO.getDocumentNumber());
+      assertThat(duplicates.getFirst().status()).isEqualTo(DuplicateRelationStatus.PENDING);
+    }
+
+    @Test
     void setStatus_withExistingPendingDuplicateRelation_shouldUpdateStatusToIgnored()
         throws DocumentationUnitNotExistsException {
       // Arrange
@@ -676,7 +802,10 @@ class DuplicateCheckIntegrationTest {
       // Assert
       assertThat(
               ((DocumentationUnit) documentationUnitService.getByUuid(original.getId()))
-                  .managementData().duplicateRelations().stream().findFirst().get().status())
+                  .managementData()
+                  .duplicateRelations()
+                  .getFirst()
+                  .status())
           .isEqualTo(DuplicateRelationStatus.IGNORED);
     }
 
@@ -724,16 +853,12 @@ class DuplicateCheckIntegrationTest {
 
       // Act
       duplicateCheckService.checkDuplicates(docUnitToBeChecked.getDocumentNumber());
-      var foundDocUnit = documentationUnitService.getByUuid(docUnitToBeChecked.getId());
+      var foundDocUnit =
+          (DocumentationUnit) documentationUnitService.getByUuid(docUnitToBeChecked.getId());
 
       // Assert
       assertThat(duplicateRelationRepository.findAll()).hasSize(1);
-      assertThat(
-              ((DocumentationUnit) foundDocUnit)
-                  .managementData().duplicateRelations().stream()
-                      .findFirst()
-                      .get()
-                      .documentNumber())
+      assertThat(foundDocUnit.managementData().duplicateRelations().getFirst().documentNumber())
           .isEqualTo(secondParams.documentNumber);
     }
 
@@ -795,16 +920,12 @@ class DuplicateCheckIntegrationTest {
 
       // Act
       duplicateCheckService.checkDuplicates(docUnitToBeChecked.getDocumentNumber());
-      var foundDocUnit = documentationUnitService.getByUuid(docUnitToBeChecked.getId());
+      var foundDocUnit =
+          (DocumentationUnit) documentationUnitService.getByUuid(docUnitToBeChecked.getId());
 
       // Assert
       assertThat(duplicateRelationRepository.findAll()).hasSize(1);
-      assertThat(
-              ((DocumentationUnit) foundDocUnit)
-                  .managementData().duplicateRelations().stream()
-                      .findFirst()
-                      .get()
-                      .documentNumber())
+      assertThat(foundDocUnit.managementData().duplicateRelations().getFirst().documentNumber())
           .isEqualTo(duplicateDTO.getDocumentNumber());
     }
 
@@ -841,16 +962,12 @@ class DuplicateCheckIntegrationTest {
 
       // Act
       duplicateCheckService.checkDuplicates(docUnitToBeChecked.getDocumentNumber());
-      var foundDocUnit = documentationUnitService.getByUuid(docUnitToBeChecked.getId());
+      var foundDocUnit =
+          (DocumentationUnit) documentationUnitService.getByUuid(docUnitToBeChecked.getId());
 
       // Assert
       assertThat(duplicateRelationRepository.findAll()).hasSize(1);
-      assertThat(
-              ((DocumentationUnit) foundDocUnit)
-                  .managementData().duplicateRelations().stream()
-                      .findFirst()
-                      .get()
-                      .documentNumber())
+      assertThat(foundDocUnit.managementData().duplicateRelations().getFirst().documentNumber())
           .isEqualTo(duplicateDTO.getDocumentNumber());
     }
 
@@ -885,16 +1002,12 @@ class DuplicateCheckIntegrationTest {
 
       // Act
       duplicateCheckService.checkDuplicates(docUnitToBeChecked.getDocumentNumber());
-      var foundDocUnit = documentationUnitService.getByUuid(docUnitToBeChecked.getId());
+      var foundDocUnit =
+          (DocumentationUnit) documentationUnitService.getByUuid(docUnitToBeChecked.getId());
 
       // Assert
       assertThat(duplicateRelationRepository.findAll()).hasSize(1);
-      assertThat(
-              ((DocumentationUnit) foundDocUnit)
-                  .managementData().duplicateRelations().stream()
-                      .findFirst()
-                      .get()
-                      .documentNumber())
+      assertThat(foundDocUnit.managementData().duplicateRelations().getFirst().documentNumber())
           .isEqualTo(duplicateDTO.getDocumentNumber());
     }
 
@@ -932,16 +1045,12 @@ class DuplicateCheckIntegrationTest {
 
       // Act
       duplicateCheckService.checkDuplicates(docUnitToBeChecked.getDocumentNumber());
-      var foundDocUnit = documentationUnitService.getByUuid(docUnitToBeChecked.getId());
+      var foundDocUnit =
+          (DocumentationUnit) documentationUnitService.getByUuid(docUnitToBeChecked.getId());
 
       // Assert
       assertThat(duplicateRelationRepository.findAll()).hasSize(1);
-      assertThat(
-              ((DocumentationUnit) foundDocUnit)
-                  .managementData().duplicateRelations().stream()
-                      .findFirst()
-                      .get()
-                      .documentNumber())
+      assertThat(foundDocUnit.managementData().duplicateRelations().getFirst().documentNumber())
           .isEqualTo(duplicateDTO.getDocumentNumber());
     }
 
@@ -978,16 +1087,12 @@ class DuplicateCheckIntegrationTest {
 
       // Act
       duplicateCheckService.checkDuplicates(docUnitToBeChecked.getDocumentNumber());
-      var foundDocUnit = documentationUnitService.getByUuid(docUnitToBeChecked.getId());
+      var foundDocUnit =
+          (DocumentationUnit) documentationUnitService.getByUuid(docUnitToBeChecked.getId());
 
       // Assert
       assertThat(duplicateRelationRepository.findAll()).hasSize(1);
-      assertThat(
-              ((DocumentationUnit) foundDocUnit)
-                  .managementData().duplicateRelations().stream()
-                      .findFirst()
-                      .get()
-                      .documentNumber())
+      assertThat(foundDocUnit.managementData().duplicateRelations().getFirst().documentNumber())
           .isEqualTo(duplicateDTO.getDocumentNumber());
     }
 
@@ -1022,16 +1127,12 @@ class DuplicateCheckIntegrationTest {
 
       // Act
       duplicateCheckService.checkDuplicates(docUnitToBeChecked.getDocumentNumber());
-      var foundDocUnit = documentationUnitService.getByUuid(docUnitToBeChecked.getId());
+      var foundDocUnit =
+          (DocumentationUnit) documentationUnitService.getByUuid(docUnitToBeChecked.getId());
 
       // Assert
       assertThat(duplicateRelationRepository.findAll()).hasSize(1);
-      assertThat(
-              ((DocumentationUnit) foundDocUnit)
-                  .managementData().duplicateRelations().stream()
-                      .findFirst()
-                      .get()
-                      .documentNumber())
+      assertThat(foundDocUnit.managementData().duplicateRelations().getFirst().documentNumber())
           .isEqualTo(duplicateDTO.getDocumentNumber());
     }
 
@@ -1062,12 +1163,11 @@ class DuplicateCheckIntegrationTest {
       // Act
       duplicateCheckService.checkDuplicates("DocumentNumb2");
 
-      var foundDocUnit = documentationUnitService.getByUuid(decision.getId());
+      var foundDocUnit = (DocumentationUnit) documentationUnitService.getByUuid(decision.getId());
 
       // Assert
       assertThat(duplicateRelationRepository.findAll()).isEmpty();
-      assertThat(((DocumentationUnit) foundDocUnit).managementData().duplicateRelations())
-          .isEmpty();
+      assertThat(foundDocUnit.managementData().duplicateRelations()).isEmpty();
     }
 
     @Test
@@ -1100,12 +1200,11 @@ class DuplicateCheckIntegrationTest {
       // Act
       duplicateCheckService.checkDuplicates("DocumentNumb2");
 
-      var foundDocUnit = documentationUnitService.getByUuid(decision.getId());
+      var foundDocUnit = (DocumentationUnit) documentationUnitService.getByUuid(decision.getId());
 
       // Assert
       assertThat(duplicateRelationRepository.findAll()).isEmpty();
-      assertThat(((DocumentationUnit) foundDocUnit).managementData().duplicateRelations())
-          .isEmpty();
+      assertThat(foundDocUnit.managementData().duplicateRelations()).isEmpty();
     }
 
     @Test
@@ -1140,12 +1239,11 @@ class DuplicateCheckIntegrationTest {
       // Act
       duplicateCheckService.checkDuplicates("DocumentNumb2");
 
-      var foundDocUnit = documentationUnitService.getByUuid(decision.getId());
+      var foundDocUnit = (DocumentationUnit) documentationUnitService.getByUuid(decision.getId());
 
       // Assert
       assertThat(duplicateRelationRepository.findAll()).isEmpty();
-      assertThat(((DocumentationUnit) foundDocUnit).managementData().duplicateRelations())
-          .isEmpty();
+      assertThat(foundDocUnit.managementData().duplicateRelations()).isEmpty();
     }
 
     @Test
@@ -1185,12 +1283,11 @@ class DuplicateCheckIntegrationTest {
       // Act
       duplicateCheckService.checkDuplicates("DocumentNumb2");
 
-      var foundDocUnit = documentationUnitService.getByUuid(decision.getId());
+      var foundDocUnit = (DocumentationUnit) documentationUnitService.getByUuid(decision.getId());
 
       // Assert
       assertThat(duplicateRelationRepository.findAll()).isEmpty();
-      assertThat(((DocumentationUnit) foundDocUnit).managementData().duplicateRelations())
-          .isEmpty();
+      assertThat(foundDocUnit.managementData().duplicateRelations()).isEmpty();
     }
 
     static Stream<Arguments> provideTestCases() {


### PR DESCRIPTION
RISDEV-6827
Also fixes a bug when GET-requesting a doc unit. The order was wrong so that the duplicates would only be included on the second request.