### PR TITLE
Fix search by file numbers

### DIFF
--- a/backend/src/main/java/de/bund/digitalservice/ris/caselaw/adapter/database/jpa/DeviatingFileNumberDTO.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/caselaw/adapter/database/jpa/DeviatingFileNumberDTO.java
@@ -4,8 +4,11 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -26,6 +29,11 @@ public class DeviatingFileNumberDTO {
   @Column(nullable = false)
   @NotBlank
   private String value;
+
+  @ManyToOne
+  @JoinColumn(name = "documentation_unit_id", nullable = false)
+  @NotNull
+  private DocumentationUnitDTO documentationUnit;
 
   private Long rank;
 }

--- a/backend/src/main/java/de/bund/digitalservice/ris/caselaw/adapter/database/jpa/DocumentationUnitDTO.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/caselaw/adapter/database/jpa/DocumentationUnitDTO.java
@@ -67,8 +67,11 @@ public abstract class DocumentationUnitDTO implements DocumentationUnitListItemD
   private DocumentTypeDTO documentType;
 
   // Aktenzeichen
-  @OneToMany(cascade = CascadeType.ALL, fetch = FetchType.LAZY, orphanRemoval = true)
-  @JoinColumn(name = "documentation_unit_id", nullable = false)
+  @OneToMany(
+      mappedBy = "documentationUnit",
+      cascade = CascadeType.ALL,
+      fetch = FetchType.LAZY,
+      orphanRemoval = true)
   @Builder.Default
   @OrderBy("rank")
   private List<FileNumberDTO> fileNumbers = new ArrayList<>();
@@ -158,8 +161,11 @@ public abstract class DocumentationUnitDTO implements DocumentationUnitListItemD
   //  private Set<DeviatingDocumentNumber> deviatingDocumentNumbers = new HashSet<>();
   //
   // Abweichendes Aktenzeichen
-  @OneToMany(cascade = CascadeType.ALL, fetch = FetchType.LAZY, orphanRemoval = true)
-  @JoinColumn(name = "documentation_unit_id", nullable = false)
+  @OneToMany(
+      mappedBy = "documentationUnit",
+      cascade = CascadeType.ALL,
+      fetch = FetchType.LAZY,
+      orphanRemoval = true)
   @Builder.Default
   @OrderBy("rank")
   private List<DeviatingFileNumberDTO> deviatingFileNumbers = new ArrayList<>();

--- a/backend/src/main/java/de/bund/digitalservice/ris/caselaw/adapter/database/jpa/FileNumberDTO.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/caselaw/adapter/database/jpa/FileNumberDTO.java
@@ -4,8 +4,11 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -27,6 +30,11 @@ public class FileNumberDTO {
   @Column(nullable = false)
   @NotBlank
   private String value;
+
+  @ManyToOne
+  @JoinColumn(name = "documentation_unit_id", nullable = false)
+  @NotNull
+  private DocumentationUnitDTO documentationUnit;
 
   private Long rank;
 }

--- a/backend/src/main/java/de/bund/digitalservice/ris/caselaw/adapter/database/jpa/PostgresDocumentationUnitRepositoryImpl.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/caselaw/adapter/database/jpa/PostgresDocumentationUnitRepositoryImpl.java
@@ -40,18 +40,15 @@ import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.springframework.context.annotation.Primary;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.SliceImpl;
@@ -146,7 +143,7 @@ public class PostgresDocumentationUnitRepositoryImpl implements DocumentationUni
   @Override
   @Transactional(transactionManager = "jpaTransactionManager")
   public DocumentationUnit createNewDocumentationUnit(
-      DocumentationUnit docUnit, Status status, Reference createdFromReference) {
+      DocumentationUnit docUnit, Status status, Reference createdFromReference, String fileNumber) {
 
     var documentationUnitDTO =
         repository.save(
@@ -179,6 +176,15 @@ public class PostgresDocumentationUnitRepositoryImpl implements DocumentationUni
     DecisionDTO.DecisionDTOBuilder<?, ?> builder =
         documentationUnitDTO.toBuilder()
             .source(sources)
+            .fileNumbers(
+                fileNumber == null
+                    ? null
+                    : List.of(
+                        FileNumberDTO.builder()
+                            .documentationUnit(documentationUnitDTO)
+                            .value(fileNumber)
+                            .rank(0L)
+                            .build()))
             .status(
                 StatusTransformer.transformToDTO(status).toBuilder()
                     .documentationUnit(documentationUnitDTO)
@@ -548,99 +554,21 @@ public class PostgresDocumentationUnitRepositoryImpl implements DocumentationUni
       Boolean myDocOfficeOnly,
       Boolean withDuplicateWarning,
       DocumentationOfficeDTO documentationOfficeDTO) {
-    if ((fileNumber == null || fileNumber.trim().isEmpty())) {
-      return repository.searchByDocumentationUnitSearchInput(
-          documentationOfficeDTO.getId(),
-          documentNumber,
-          courtType,
-          courtLocation,
-          decisionDate,
-          decisionDateEnd,
-          publicationDate,
-          scheduledOnly,
-          status,
-          withError,
-          myDocOfficeOnly,
-          withDuplicateWarning,
-          pageable);
-    }
-
-    // The highest possible number of results - For page 0: 30, for page 1: 60, for page 2: 90, etc.
-    int maxResultsUpToCurrentPage = (pageable.getPageNumber() + 1) * pageable.getPageSize();
-
-    // We need to start with index 0 because we collect 3 results sets, each of the desired size of
-    // the page. Then we sort the full ist and cut it to the page size (possibly leaving 2x page
-    // size results behind). If we don't always start with index 0, we might miss results.
-    // This approach could even be better if we replace the next/previous with a "load more" button
-    Pageable fixedPageRequest = PageRequest.of(0, maxResultsUpToCurrentPage);
-
-    Slice<DocumentationUnitListItemDTO> fileNumberResults = new SliceImpl<>(List.of());
-    Slice<DocumentationUnitListItemDTO> deviatingFileNumberResults = new SliceImpl<>(List.of());
-
-    if (!fileNumber.trim().isEmpty()) {
-      fileNumberResults =
-          repository.searchByDocumentationUnitSearchInputFileNumber(
-              documentationOfficeDTO.getId(),
-              documentNumber,
-              fileNumber.trim(),
-              courtType,
-              courtLocation,
-              decisionDate,
-              decisionDateEnd,
-              publicationDate,
-              scheduledOnly,
-              status,
-              withError,
-              myDocOfficeOnly,
-              withDuplicateWarning,
-              fixedPageRequest);
-
-      deviatingFileNumberResults =
-          repository.searchByDocumentationUnitSearchInputDeviatingFileNumber(
-              documentationOfficeDTO.getId(),
-              documentNumber,
-              fileNumber.trim(),
-              courtType,
-              courtLocation,
-              decisionDate,
-              decisionDateEnd,
-              publicationDate,
-              scheduledOnly,
-              status,
-              withError,
-              myDocOfficeOnly,
-              withDuplicateWarning,
-              fixedPageRequest);
-    }
-
-    Set<DocumentationUnitListItemDTO> allResults = new HashSet<>();
-
-    allResults.addAll(fileNumberResults.getContent());
-    allResults.addAll(deviatingFileNumberResults.getContent());
-
-    // We can provide entries for a next page if ...
-    // A) we already have collected more results than fit on the current page, or
-    // B) at least one of the queries has more results
-    boolean hasNext =
-        allResults.size() >= maxResultsUpToCurrentPage
-            || fileNumberResults.hasNext()
-            || deviatingFileNumberResults.hasNext();
-
-    return new SliceImpl<>(
-        allResults.stream()
-            .sorted(
-                (o1, o2) -> {
-                  if (o1.getDate() != null && o2.getDate() != null) {
-                    return o1.getDocumentNumber().compareTo(o2.getDocumentNumber());
-                  }
-                  return 0;
-                })
-            .toList()
-            .subList(
-                pageable.getPageNumber() * pageable.getPageSize(),
-                Math.min(allResults.size(), maxResultsUpToCurrentPage)),
-        pageable,
-        hasNext);
+    return repository.searchByDocumentationUnitSearchInput(
+        documentationOfficeDTO.getId(),
+        documentNumber,
+        fileNumber,
+        courtType,
+        courtLocation,
+        decisionDate,
+        decisionDateEnd,
+        publicationDate,
+        scheduledOnly,
+        status,
+        withError,
+        myDocOfficeOnly,
+        withDuplicateWarning,
+        pageable);
   }
 
   @Transactional(transactionManager = "jpaTransactionManager", readOnly = true)

--- a/backend/src/main/java/de/bund/digitalservice/ris/caselaw/adapter/transformer/DecisionTransformer.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/caselaw/adapter/transformer/DecisionTransformer.java
@@ -94,10 +94,10 @@ public class DecisionTransformer extends DocumentableTransformer {
       addLeadingDecisionNormReferences(updatedDomainObject, builder);
       addYearsOfDisputeToDTO(builder, coreData);
 
-      addFileNumbers(builder, coreData);
+      addFileNumbers(builder, coreData, currentDto);
       addDeviationCourts(builder, coreData);
       addDeviatingDecisionDates(builder, coreData);
-      addDeviatingFileNumbers(builder, coreData);
+      addDeviatingFileNumbers(builder, coreData, currentDto);
       addSource(currentDto, builder, updatedDomainObject);
 
     } else {

--- a/backend/src/main/java/de/bund/digitalservice/ris/caselaw/adapter/transformer/DocumentableTransformer.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/caselaw/adapter/transformer/DocumentableTransformer.java
@@ -1,6 +1,7 @@
 package de.bund.digitalservice.ris.caselaw.adapter.transformer;
 
 import de.bund.digitalservice.ris.caselaw.adapter.database.jpa.CaselawReferenceDTO;
+import de.bund.digitalservice.ris.caselaw.adapter.database.jpa.DecisionDTO;
 import de.bund.digitalservice.ris.caselaw.adapter.database.jpa.DeviatingCourtDTO;
 import de.bund.digitalservice.ris.caselaw.adapter.database.jpa.DeviatingDateDTO;
 import de.bund.digitalservice.ris.caselaw.adapter.database.jpa.DeviatingFileNumberDTO;
@@ -188,7 +189,9 @@ public class DocumentableTransformer {
   }
 
   static void addDeviatingFileNumbers(
-      DocumentationUnitDTO.DocumentationUnitDTOBuilder<?, ?> builder, CoreData coreData) {
+      DocumentationUnitDTO.DocumentationUnitDTOBuilder<?, ?> builder,
+      CoreData coreData,
+      DecisionDTO currentDto) {
     if (coreData.deviatingFileNumbers() == null) {
       return;
     }
@@ -200,6 +203,7 @@ public class DocumentableTransformer {
       deviatingFileNumberDTOs.add(
           DeviatingFileNumberDTO.builder()
               .value(StringUtils.normalizeSpace(deviatingFileNumbers.get(i)))
+              .documentationUnit(currentDto)
               .rank(i + 1L)
               .build());
     }
@@ -245,7 +249,9 @@ public class DocumentableTransformer {
   }
 
   static void addFileNumbers(
-      DocumentationUnitDTO.DocumentationUnitDTOBuilder<?, ?> builder, CoreData coreData) {
+      DocumentationUnitDTO.DocumentationUnitDTOBuilder<?, ?> builder,
+      CoreData coreData,
+      DecisionDTO currentDto) {
     if (coreData.fileNumbers() == null) {
       return;
     }
@@ -257,6 +263,7 @@ public class DocumentableTransformer {
       fileNumberDTOs.add(
           FileNumberDTO.builder()
               .value(StringUtils.normalizeSpace(fileNumbers.get(i)))
+              .documentationUnit(currentDto)
               .rank(i + 1L)
               .build());
     }

--- a/backend/src/main/java/de/bund/digitalservice/ris/caselaw/domain/DocumentationUnitRepository.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/caselaw/domain/DocumentationUnitRepository.java
@@ -39,10 +39,14 @@ public interface DocumentationUnitRepository {
    * @param documentationUnit the documentation unit to create
    * @param status the status of the new documentation unit
    * @param createdFromReference the reference the documentation unit is created from
+   * @param fileNumber Aktenzeichen
    * @return the new documentation unit
    */
   DocumentationUnit createNewDocumentationUnit(
-      DocumentationUnit documentationUnit, Status status, Reference createdFromReference);
+      DocumentationUnit documentationUnit,
+      Status status,
+      Reference createdFromReference,
+      String fileNumber);
 
   /**
    * Save a documentation unit

--- a/backend/src/main/java/de/bund/digitalservice/ris/caselaw/domain/DocumentationUnitService.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/caselaw/domain/DocumentationUnitService.java
@@ -96,7 +96,6 @@ public class DocumentationUnitService {
             .coreData(
                 CoreData.builder()
                     .documentationOffice(params.documentationOffice())
-                    .fileNumbers(params.fileNumber() == null ? null : List.of(params.fileNumber()))
                     .documentType(params.documentType())
                     .decisionDate(params.decisionDate())
                     .court(params.court())
@@ -121,8 +120,9 @@ public class DocumentationUnitService {
             .withError(false)
             .build();
 
-    var newDocumentationUnit =
-        repository.createNewDocumentationUnit(docUnit, status, params.reference());
+    DocumentationUnit newDocumentationUnit =
+        repository.createNewDocumentationUnit(
+            docUnit, status, params.reference(), params.fileNumber());
 
     duplicateCheckService.checkDuplicates(docUnit.documentNumber());
     return newDocumentationUnit;

--- a/backend/src/test/java/de/bund/digitalservice/ris/caselaw/EntityBuilderTestUtil.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/caselaw/EntityBuilderTestUtil.java
@@ -164,7 +164,20 @@ public class EntityBuilderTestUtil {
       PublicationStatus publicationStatus,
       boolean errorStatus) {
 
-    DecisionDTO dto = repository.save(builder.build());
+    var dtoBeforeSave = builder.build();
+
+    // FileNumbers need back reference to docUnit -> needs to be saved first without them
+    var fileNumbers = dtoBeforeSave.getFileNumbers();
+    dtoBeforeSave.setFileNumbers(null);
+    var devatingFileNumbers = dtoBeforeSave.getDeviatingFileNumbers();
+    dtoBeforeSave.setDeviatingFileNumbers(null);
+
+    DecisionDTO dto = repository.save(dtoBeforeSave);
+
+    fileNumbers.forEach(fn -> fn.setDocumentationUnit(dto));
+    devatingFileNumbers.forEach(fn -> fn.setDocumentationUnit(dto));
+    dto.setFileNumbers(fileNumbers);
+    dto.setDeviatingFileNumbers(devatingFileNumbers);
 
     return repository.save(
         dto.toBuilder()

--- a/backend/src/test/java/de/bund/digitalservice/ris/caselaw/domain/DocumentationUnitServiceTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/caselaw/domain/DocumentationUnitServiceTest.java
@@ -83,7 +83,8 @@ class DocumentationUnitServiceTest {
         DocumentationOffice.builder().uuid(UUID.randomUUID()).build();
     DocumentationUnit documentationUnit = DocumentationUnit.builder().build();
 
-    when(repository.createNewDocumentationUnit(any(), any(), any())).thenReturn(documentationUnit);
+    when(repository.createNewDocumentationUnit(any(), any(), any(), any()))
+        .thenReturn(documentationUnit);
     when(documentNumberService.generateDocumentNumber(documentationOffice.abbreviation()))
         .thenReturn("nextDocumentNumber");
     // Can we use a captor to check if the document number was correctly created?
@@ -109,6 +110,7 @@ class DocumentationUnitServiceTest {
                 .publicationStatus(PublicationStatus.UNPUBLISHED)
                 .withError(false)
                 .build(),
+            null,
             null);
   }
 
@@ -136,7 +138,8 @@ class DocumentationUnitServiceTest {
                     .build())
             .build();
 
-    when(repository.createNewDocumentationUnit(any(), any(), any())).thenReturn(documentationUnit);
+    when(repository.createNewDocumentationUnit(any(), any(), any(), any()))
+        .thenReturn(documentationUnit);
 
     when(documentNumberService.generateDocumentNumber(designatedDocumentationOffice.abbreviation()))
         .thenReturn("nextDocumentNumber");
@@ -158,7 +161,6 @@ class DocumentationUnitServiceTest {
                     CoreData.builder()
                         .creatingDocOffice(userDocumentationOffice)
                         .documentationOffice(designatedDocumentationOffice)
-                        .fileNumbers(List.of(parameters.fileNumber()))
                         .court(parameters.court())
                         .legalEffect(LegalEffect.YES.getLabel())
                         .decisionDate(parameters.decisionDate())
@@ -169,7 +171,8 @@ class DocumentationUnitServiceTest {
                 .publicationStatus(PublicationStatus.EXTERNAL_HANDOVER_PENDING)
                 .withError(false)
                 .build(),
-            parameters.reference());
+            parameters.reference(),
+            parameters.fileNumber());
   }
 
   @Test

--- a/backend/src/test/java/de/bund/digitalservice/ris/caselaw/integration/tests/DocumentationUnitSearchIntegrationTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/caselaw/integration/tests/DocumentationUnitSearchIntegrationTest.java
@@ -167,12 +167,12 @@ class DocumentationUnitSearchIntegrationTest {
         .extracting("documentNumber", "fileNumber", "status")
         .containsExactly(
             tuple(
-                "MIGR202200012",
-                "AkteM",
-                Status.builder().publicationStatus(PublicationStatus.PUBLISHED).build()),
-            tuple(
                 "NEUR202300008",
                 "AkteY",
+                Status.builder().publicationStatus(PublicationStatus.PUBLISHED).build()),
+            tuple(
+                "MIGR202200012",
+                "AkteM",
                 Status.builder().publicationStatus(PublicationStatus.PUBLISHED).build()));
     assertThat(responseBody.getNumberOfElements()).isEqualTo(2);
   }
@@ -413,6 +413,7 @@ class DocumentationUnitSearchIntegrationTest {
               // index 0-4 get a "AB" docNumber
               .documentNumber((i <= 4 ? "AB" : "GE") + "123456780" + i)
               .documentationOffice(docOfficeDTO)
+              .date(LocalDate.of(2022, 1, 20 - i))
               .fileNumbers(
                   // even indices get a fileNumber
                   i % 2 == 1

--- a/backend/src/test/java/de/bund/digitalservice/ris/caselaw/integration/tests/DuplicateCheckFullIntegrationTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/caselaw/integration/tests/DuplicateCheckFullIntegrationTest.java
@@ -836,61 +836,103 @@ class DuplicateCheckFullIntegrationTest {
         checkDuplicates_pendingProceedingWithFullyDuplicatedAttributes_shouldProduceNoDuplicateRelations()
             throws DocumentationUnitNotExistsException {
       // Arrange
+      var dto1 =
+          repository.save(
+              PendingProceedingDTO.builder()
+                  .documentationOffice(documentationOffice)
+                  .date(LocalDate.of(2023, 12, 11))
+                  .deviatingDates(
+                      List.of(
+                          DeviatingDateDTO.builder()
+                              .rank(0L)
+                              .value(LocalDate.of(2023, 12, 11))
+                              .build()))
+                  .documentNumber("DocumentNumb1")
+                  .court(CourtTransformer.transformToDTO(courtAgAachen))
+                  .deviatingCourts(
+                      List.of(DeviatingCourtDTO.builder().rank(0L).value("AG Aachen").build()))
+                  .documentType(DocumentTypeTransformer.transformToDTO(documentType1))
+                  .build());
       var pendingProceedingDTO1 =
-          PendingProceedingDTO.builder()
-              .documentationOffice(documentationOffice)
-              .date(LocalDate.of(2023, 12, 11))
-              .deviatingDates(
+          dto1.toBuilder()
+              .fileNumbers(
                   List.of(
-                      DeviatingDateDTO.builder()
+                      FileNumberDTO.builder()
+                          .documentationUnit(dto1)
                           .rank(0L)
-                          .value(LocalDate.of(2023, 12, 11))
+                          .value("123")
                           .build()))
-              .documentNumber("DocumentNumb1")
-              .court(CourtTransformer.transformToDTO(courtAgAachen))
-              .deviatingCourts(
-                  List.of(DeviatingCourtDTO.builder().rank(0L).value("AG Aachen").build()))
-              .documentType(DocumentTypeTransformer.transformToDTO(documentType1))
-              .fileNumbers(List.of(FileNumberDTO.builder().rank(0L).value("123").build()))
               .deviatingFileNumbers(
-                  List.of(DeviatingFileNumberDTO.builder().rank(0L).value("123").build()))
+                  List.of(
+                      DeviatingFileNumberDTO.builder()
+                          .documentationUnit(dto1)
+                          .rank(0L)
+                          .value("123")
+                          .build()))
               .build();
+      var dto2 =
+          repository.save(
+              PendingProceedingDTO.builder()
+                  .documentationOffice(documentationOffice)
+                  .documentationOffice(documentationOffice)
+                  .date(LocalDate.of(2023, 12, 11))
+                  .deviatingDates(
+                      List.of(
+                          DeviatingDateDTO.builder()
+                              .rank(0L)
+                              .value(LocalDate.of(2023, 12, 11))
+                              .build()))
+                  .documentNumber("DocumentNumb2")
+                  .court(CourtTransformer.transformToDTO(courtAgAachen))
+                  .deviatingCourts(
+                      List.of(DeviatingCourtDTO.builder().rank(0L).value("AG Aachen").build()))
+                  .documentType(DocumentTypeTransformer.transformToDTO(documentType1))
+                  .build());
       var pendingProceedingDTO2 =
-          PendingProceedingDTO.builder()
-              .documentationOffice(documentationOffice)
-              .date(LocalDate.of(2023, 12, 11))
-              .deviatingDates(
+          dto2.toBuilder()
+              .fileNumbers(
                   List.of(
-                      DeviatingDateDTO.builder()
+                      FileNumberDTO.builder()
+                          .documentationUnit(dto2)
                           .rank(0L)
-                          .value(LocalDate.of(2023, 12, 11))
+                          .value("123")
                           .build()))
-              .documentNumber("DocumentNumb2")
-              .court(CourtTransformer.transformToDTO(courtAgAachen))
-              .deviatingCourts(
-                  List.of(DeviatingCourtDTO.builder().rank(0L).value("AG Aachen").build()))
-              .documentType(DocumentTypeTransformer.transformToDTO(documentType1))
-              .fileNumbers(List.of(FileNumberDTO.builder().rank(0L).value("123").build()))
               .deviatingFileNumbers(
-                  List.of(DeviatingFileNumberDTO.builder().rank(0L).value("123").build()))
+                  List.of(
+                      DeviatingFileNumberDTO.builder()
+                          .documentationUnit(dto2)
+                          .rank(0L)
+                          .value("123")
+                          .build()))
               .build();
+
+      var dto3 =
+          repository.save(
+              DecisionDTO.builder()
+                  .documentationOffice(documentationOffice)
+                  .documentationOffice(documentationOffice)
+                  .date(LocalDate.of(2023, 12, 11))
+                  .deviatingDates(
+                      List.of(
+                          DeviatingDateDTO.builder()
+                              .rank(0L)
+                              .value(LocalDate.of(2023, 12, 11))
+                              .build()))
+                  .documentNumber("DocumentNumb3")
+                  .court(CourtTransformer.transformToDTO(courtAgAachen))
+                  .deviatingCourts(
+                      List.of(DeviatingCourtDTO.builder().rank(0L).value("AG Aachen").build()))
+                  .documentType(DocumentTypeTransformer.transformToDTO(documentType1))
+                  .build());
       var decisionDTO =
-          DecisionDTO.builder()
-              .documentationOffice(documentationOffice)
-              .date(LocalDate.of(2023, 12, 11))
-              .deviatingDates(
-                  List.of(
-                      DeviatingDateDTO.builder()
-                          .rank(0L)
-                          .value(LocalDate.of(2023, 12, 11))
-                          .build()))
-              .documentNumber("DocumentNumb3")
-              .court(CourtTransformer.transformToDTO(courtAgAachen))
-              .deviatingCourts(
-                  List.of(DeviatingCourtDTO.builder().rank(0L).value("AG Aachen").build()))
-              .documentType(DocumentTypeTransformer.transformToDTO(documentType1))
+          dto3.toBuilder()
               .deviatingFileNumbers(
-                  List.of(DeviatingFileNumberDTO.builder().rank(0L).value("123").build()))
+                  List.of(
+                      DeviatingFileNumberDTO.builder()
+                          .rank(0L)
+                          .value("123")
+                          .documentationUnit(dto3)
+                          .build()))
               .build();
 
       repository.save(pendingProceedingDTO1);
@@ -1320,8 +1362,6 @@ class DuplicateCheckFullIntegrationTest {
             .coreData(
                 CoreData.builder()
                     .documentationOffice(params.documentationOffice())
-                    .fileNumbers(params.fileNumbers())
-                    .deviatingFileNumbers(params.deviatingFileNumbers())
                     .documentType(params.documentType())
                     .decisionDate(params.decisionDate())
                     .deviatingDecisionDates(params.deviatingDecisionDates())
@@ -1346,6 +1386,39 @@ class DuplicateCheckFullIntegrationTest {
                     .isJdvDuplicateCheckActive(params.isJdvDuplicateCheckActive())
                     .build(),
                 docUnit));
+
+    if (params.fileNumbers() != null) {
+      DecisionDTO finalDocumentationUnitDTO = documentationUnitDTO;
+      var fileNumbers =
+          params.fileNumbers.stream()
+              .map(
+                  fileNumber ->
+                      FileNumberDTO.builder()
+                          .documentationUnit(finalDocumentationUnitDTO)
+                          .value(fileNumber)
+                          .rank(0L)
+                          .build())
+              .toList();
+
+      documentationUnitDTO = documentationUnitDTO.toBuilder().fileNumbers(fileNumbers).build();
+    }
+
+    if (params.deviatingFileNumbers() != null) {
+      DecisionDTO finalDocumentationUnitDTO = documentationUnitDTO;
+      var devfileNumbers =
+          params.deviatingFileNumbers.stream()
+              .map(
+                  fileNumber ->
+                      DeviatingFileNumberDTO.builder()
+                          .documentationUnit(finalDocumentationUnitDTO)
+                          .value(fileNumber)
+                          .rank(0L)
+                          .build())
+              .toList();
+
+      documentationUnitDTO =
+          documentationUnitDTO.toBuilder().deviatingFileNumbers(devfileNumbers).build();
+    }
 
     if (params.publicationStatus != null) {
       documentationUnitDTO =

--- a/backend/src/test/java/de/bund/digitalservice/ris/caselaw/integration/tests/LegalPeriodicalEditionIntegrationTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/caselaw/integration/tests/LegalPeriodicalEditionIntegrationTest.java
@@ -752,9 +752,11 @@ class LegalPeriodicalEditionIntegrationTest {
     referenceRepository.save(reference);
 
     // add status and source
+    var fileNumber = EntityBuilderTestUtil.createTestFileNumberDTO();
+    fileNumber.setDocumentationUnit(docUnit);
     documentationUnitRepository.save(
         docUnit.toBuilder()
-            .fileNumbers(List.of(EntityBuilderTestUtil.createTestFileNumberDTO()))
+            .fileNumbers(List.of(fileNumber))
             .source(
                 new ArrayList<>(
                     List.of(


### PR DESCRIPTION
https://github.com/user-attachments/assets/78ce0cd3-943a-49de-bb35-8bebf64e3343

RISDEV-5686
Searching by file numbers would lead to wrong order and pagination. The JOIN would count a docUnit with two file numbers twice.

As there was no stable order for documents with the same date, the pagination was unreliable. Ordering by docNumber gives stable order.