### PR TITLE
[DO NOT MERGE] Showcase V8 line coverage breaks FieldsOfLaw.vue

### DIFF
--- a/frontend/test/components/documentUnit/documentUnitCategories.spec.ts
+++ b/frontend/test/components/documentUnit/documentUnitCategories.spec.ts
@@ -25,6 +25,9 @@ function renderComponent() {
       },
       global: {
         directives: { "ctrl-enter": onSearchShortcutDirective },
+        stubs: {
+          FieldsOfLaw: true,
+        },
         plugins: [
           createTestingPinia({
             initialState: {

--- a/frontend/test/components/fieldOfLaw/FieldsOfLaw.spec.ts
+++ b/frontend/test/components/fieldOfLaw/FieldsOfLaw.spec.ts
@@ -1,0 +1,529 @@
+import { createTestingPinia } from "@pinia/testing"
+import { userEvent } from "@testing-library/user-event"
+import { render, screen, waitFor } from "@testing-library/vue"
+import FieldsOfLawVue from "@/components/field-of-law/FieldsOfLaw.vue"
+import DocumentUnit from "@/domain/documentUnit"
+import FieldOfLawService from "@/services/fieldOfLawService"
+
+function renderComponent() {
+  const user = userEvent.setup()
+  return {
+    user,
+    ...render(FieldsOfLawVue, {
+      global: {
+        stubs: {
+          // this way the comboboxItemService is not triggered
+          FieldOfLawDirectInputSearch: true,
+        },
+        plugins: [
+          [
+            createTestingPinia({
+              initialState: {
+                docunitStore: {
+                  documentUnit: new DocumentUnit("foo", {
+                    documentNumber: "1234567891234",
+                    contentRelatedIndexing: {
+                      fieldsOfLaw: [],
+                    },
+                  }),
+                },
+              },
+            }),
+          ],
+        ],
+      },
+    }),
+  }
+}
+
+describe("FieldsOfLaw", () => {
+  const getChildrenOfRoot = () =>
+    Promise.resolve({
+      status: 200,
+      data: [
+        {
+          hasChildren: true,
+          identifier: "PR",
+          text: "Phantasierecht",
+          linkedFields: [],
+          norms: [],
+          children: [],
+        },
+        {
+          hasChildren: true,
+          identifier: "AV",
+          text: "Allgemeines Verwaltungsrecht",
+          linkedFields: [],
+          norms: [],
+          children: [],
+        },
+        {
+          identifier: "AB-01",
+          text: "Text for AB",
+          children: [],
+          norms: [],
+          isExpanded: false,
+          hasChildren: false,
+        },
+        {
+          identifier: "CD-02",
+          text: "And text for CD with link to AB-01",
+          children: [],
+          norms: [],
+          linkedFields: ["AB-01"],
+          isExpanded: false,
+          hasChildren: false,
+        },
+      ],
+    })
+  const getChildrenOfPR = () =>
+    Promise.resolve({
+      status: 200,
+      data: [
+        {
+          hasChildren: true,
+          identifier: "PR-05",
+          text: "Beendigung der Phantasieverhältnisse",
+          linkedFields: [],
+          norms: [
+            {
+              abbreviation: "PStG",
+              singleNormDescription: "§ 99",
+            },
+          ],
+          children: [],
+          parent: {
+            hasChildren: true,
+            identifier: "PR",
+            text: "Phantasierecht",
+            linkedFields: [],
+            norms: [],
+            children: [],
+            parent: undefined,
+          },
+        },
+      ],
+    })
+  const getChildrenOfPRO5 = () =>
+    Promise.resolve({
+      status: 200,
+      data: [
+        {
+          hasChildren: false,
+          identifier: "PR-05-01",
+          text: "Phantasie besonderer Art, Ansprüche anderer Art",
+          norms: [],
+          children: [],
+          parent: {
+            hasChildren: true,
+            identifier: "PR-05",
+            text: "Beendigung der Phantasieverhältnisse",
+            linkedFields: [],
+            norms: [
+              {
+                abbreviation: "PStG",
+                singleNormDescription: "§ 99",
+              },
+            ],
+            children: [],
+            parent: {
+              hasChildren: true,
+              identifier: "PR",
+              text: "Phantasierecht",
+              norms: [],
+              children: [],
+            },
+          },
+        },
+      ],
+    })
+  const getChildrenOfPR0501 = () =>
+    Promise.resolve({
+      status: 200,
+      data: [
+        {
+          hasChildren: false,
+          identifier: "PR-05-01",
+          text: "Phantasie besonderer Art, Ansprüche anderer Art",
+          norms: [],
+          children: [],
+          parent: {
+            hasChildren: true,
+            identifier: "PR-05",
+            text: "Beendigung der Phantasieverhältnisse",
+            linkedFields: [],
+            norms: [
+              {
+                abbreviation: "PStG",
+                singleNormDescription: "§ 99",
+              },
+            ],
+            children: [],
+            parent: {
+              hasChildren: true,
+              identifier: "PR",
+              text: "Phantasierecht",
+              norms: [],
+              children: [],
+            },
+          },
+        },
+      ],
+    })
+  const getParentAndChildrenForIdentifierPR05 = () =>
+    Promise.resolve({
+      status: 200,
+      data: {
+        hasChildren: true,
+        identifier: "PR-05",
+        text: "Beendigung der Phantasieverhältnisse",
+        norms: [
+          {
+            abbreviation: "PStG",
+            singleNormDescription: "§ 99",
+          },
+        ],
+        children: [
+          {
+            hasChildren: false,
+            identifier: "PR-05-01",
+            text: "Phantasie besonderer Art, Ansprüche anderer Art",
+            norms: [],
+            children: [],
+            parent: {
+              hasChildren: true,
+              identifier: "PR-05",
+              text: "Beendigung der Phantasieverhältnisse",
+              linkedFields: [],
+              norms: [
+                {
+                  abbreviation: "PStG",
+                  singleNormDescription: "§ 99",
+                },
+              ],
+              children: [],
+              parent: {
+                hasChildren: true,
+                identifier: "PR",
+                text: "Phantasierecht",
+                norms: [],
+                children: [],
+              },
+            },
+          },
+        ],
+        parent: {
+          id: "a785fb96-a45d-4d4c-8d9c-92d8a6592b22",
+          hasChildren: true,
+          identifier: "PR",
+          text: "Phantasierecht",
+          norms: [],
+          children: [],
+        },
+      },
+    })
+  const searchForFieldsOfLawForPR05 = () =>
+    Promise.resolve({
+      status: 200,
+      data: {
+        content: [
+          {
+            hasChildren: true,
+            identifier: "PR-05",
+            text: "Beendigung der Phantasieverhältnisse",
+            norms: [
+              {
+                abbreviation: "PStG",
+                singleNormDescription: "§ 99",
+              },
+            ],
+            children: [],
+            parent: {
+              id: "a785fb96-a45d-4d4c-8d9c-92d8a6592b22",
+              hasChildren: true,
+              identifier: "PR",
+              text: "Phantasierecht",
+              norms: [],
+              children: [],
+            },
+          },
+          {
+            hasChildren: false,
+            identifier: "PR-05-01",
+            text: "Phantasie besonderer Art, Ansprüche anderer Art",
+            norms: [],
+            children: [],
+            parent: {
+              hasChildren: true,
+              identifier: "PR-05",
+              text: "Beendigung der Phantasieverhältnisse",
+              norms: [
+                {
+                  abbreviation: "PStG",
+                  singleNormDescription: "§ 99",
+                },
+              ],
+              children: [],
+              parent: {
+                id: "a785fb96-a45d-4d4c-8d9c-92d8a6592b22",
+                hasChildren: true,
+                identifier: "PR",
+                text: "Phantasierecht",
+                norms: [],
+                children: [],
+              },
+            },
+          },
+        ],
+        size: 2,
+        number: 0,
+        numberOfElements: 2,
+        first: true,
+        last: true,
+        empty: false,
+      },
+    })
+  const searchForFieldsOfLawFail = () =>
+    Promise.resolve({
+      status: 500,
+      error: {
+        title: "Something went wrong",
+      },
+    })
+
+  beforeEach(() => {
+    vi.spyOn(FieldOfLawService, "getChildrenOf").mockImplementation(
+      (identifier: string) => {
+        if (identifier == "root") return getChildrenOfRoot()
+        else if (identifier == "PR") return getChildrenOfPR()
+        else if (identifier == "PR-05") return getChildrenOfPRO5()
+        return getChildrenOfPR0501()
+      },
+    )
+    vi.spyOn(FieldOfLawService, "getTreeForIdentifier").mockImplementation(
+      () => {
+        return getParentAndChildrenForIdentifierPR05()
+      },
+    )
+    vi.spyOn(FieldOfLawService, "searchForFieldsOfLaw").mockImplementation(
+      () => {
+        return searchForFieldsOfLawForPR05()
+      },
+    )
+  })
+
+  it("Shows button Sachgebiete", async () => {
+    // given when
+    renderComponent()
+
+    // then
+    expect(
+      screen.getByRole("button", { name: "Sachgebiete" }),
+    ).toBeInTheDocument()
+  })
+
+  it("Shows Radio group when clicking Sachgebiete button", async () => {
+    // given
+    const { user } = renderComponent()
+
+    // when
+    await user.click(screen.getByRole("button", { name: "Sachgebiete" }))
+
+    // then
+    expect(screen.getByLabelText("Suche")).toBeInTheDocument()
+  })
+
+  it("Shows error message when no search term is entered", async () => {
+    // given
+    const { user } = renderComponent()
+
+    // when
+    await user.click(screen.getByRole("button", { name: "Sachgebiete" }))
+    await user.click(screen.getByLabelText("Suche"))
+    await user.click(
+      screen.getByRole("button", { name: "Sachgebietssuche ausführen" }),
+    )
+
+    // then
+    expect(
+      screen.getByText("Geben Sie mindestens ein Suchkriterium ein"),
+    ).toBeInTheDocument()
+  })
+
+  it("Lists search results", async () => {
+    // given
+    const { user } = renderComponent()
+
+    // when
+    await user.click(screen.getByRole("button", { name: "Sachgebiete" }))
+    await user.click(screen.getByLabelText("Suche"))
+    await user.type(screen.getByLabelText("Sachgebietskürzel"), "PR-05")
+    await user.click(
+      screen.getByRole("button", { name: "Sachgebietssuche ausführen" }),
+    )
+
+    // then
+    await waitFor(() => {
+      expect(
+        screen.getAllByText("Beendigung der Phantasieverhältnisse")[0],
+      ).toBeInTheDocument()
+    })
+  })
+
+  it("Shows norms when required", async () => {
+    // given
+    const { user } = renderComponent()
+
+    // when
+    await user.click(screen.getByRole("button", { name: "Sachgebiete" }))
+    await user.click(screen.getByLabelText("Suche"))
+    await user.type(screen.getByLabelText("Sachgebietskürzel"), "PR-05")
+    await user.click(
+      screen.getByRole("button", { name: "Sachgebietssuche ausführen" }),
+    )
+    await user.click(screen.getAllByRole("checkbox")[0])
+
+    // then
+    await waitFor(() => {
+      expect(screen.getByText("§ 99")).toBeInTheDocument()
+    })
+  })
+
+  it("Shows warning when backend responds with error message", async () => {
+    // given
+    vi.spyOn(FieldOfLawService, "searchForFieldsOfLaw").mockImplementation(
+      () => {
+        return searchForFieldsOfLawFail()
+      },
+    )
+    const { user } = renderComponent()
+
+    // when
+    await user.click(screen.getByRole("button", { name: "Sachgebiete" }))
+    await user.click(screen.getByLabelText("Suche"))
+    await user.type(
+      screen.getByLabelText("Sachgebietskürzel"),
+      "this triggers an error",
+    )
+    await user.click(
+      screen.getByRole("button", { name: "Sachgebietssuche ausführen" }),
+    )
+
+    // then
+    await waitFor(() => {
+      expect(
+        screen.getByText(
+          "Leider ist ein Fehler aufgetreten. Bitte versuchen Sie es zu einem späteren Zeitpunkt erneut.",
+        ),
+      ).toBeInTheDocument()
+    })
+  })
+
+  it("Resets search results", async () => {
+    // given
+    const { user } = renderComponent()
+
+    // when
+    await user.click(screen.getByRole("button", { name: "Sachgebiete" }))
+    await user.click(screen.getByLabelText("Suche"))
+    await user.type(screen.getByLabelText("Sachgebietskürzel"), "PR-05")
+    await user.click(
+      screen.getByRole("button", { name: "Sachgebietssuche ausführen" }),
+    )
+    await waitFor(() => {
+      expect(
+        screen.getAllByText("Beendigung der Phantasieverhältnisse")[0],
+      ).toBeInTheDocument()
+    })
+    await user.click(screen.getByRole("button", { name: "Suche zurücksetzen" }))
+
+    // then
+    expect(
+      screen.queryByText("Beendigung der Phantasieverhältnisse"),
+    ).not.toBeInTheDocument()
+  })
+
+  it("Adds a field of law to the selection", async () => {
+    // given
+    const { user } = renderComponent()
+
+    // when
+    await user.click(screen.getByRole("button", { name: "Sachgebiete" }))
+    await user.click(screen.getByLabelText("Suche"))
+    await user.type(screen.getByLabelText("Sachgebietskürzel"), "PR-05")
+    await user.click(
+      screen.getByRole("button", { name: "Sachgebietssuche ausführen" }),
+    )
+    await waitFor(() => {
+      expect(
+        screen.getAllByText("Beendigung der Phantasieverhältnisse")[0],
+      ).toBeInTheDocument()
+    })
+    await user.click(screen.getByLabelText("PR-05 hinzufügen"))
+
+    // then
+    expect(
+      screen.getByRole("button", {
+        name: "PR-05 Beendigung der Phantasieverhältnisse aus Liste entfernen",
+      }),
+    ).toBeInTheDocument()
+  })
+
+  it("Cannot add a field of law to the selection twice", async () => {
+    // given
+    const { user } = renderComponent()
+
+    // when
+    await user.click(screen.getByRole("button", { name: "Sachgebiete" }))
+    await user.click(screen.getByLabelText("Suche"))
+    await user.type(screen.getByLabelText("Sachgebietskürzel"), "PR-05")
+    await user.click(
+      screen.getByRole("button", { name: "Sachgebietssuche ausführen" }),
+    )
+    await waitFor(() => {
+      expect(
+        screen.getAllByText("Beendigung der Phantasieverhältnisse")[0],
+      ).toBeInTheDocument()
+    })
+    await user.click(screen.getByLabelText("PR-05 hinzufügen"))
+    await user.click(screen.getByLabelText("PR-05 hinzufügen"))
+
+    // then
+    expect(
+      screen.getAllByRole("button", {
+        name: "PR-05 Beendigung der Phantasieverhältnisse aus Liste entfernen",
+      }).length,
+    ).toBe(1)
+  })
+
+  it("Remove a selected field of law", async () => {
+    // given
+    const { user } = renderComponent()
+
+    // when
+    await user.click(screen.getByRole("button", { name: "Sachgebiete" }))
+    await user.click(screen.getByLabelText("Suche"))
+    await user.type(screen.getByLabelText("Sachgebietskürzel"), "PR-05")
+    await user.click(
+      screen.getByRole("button", { name: "Sachgebietssuche ausführen" }),
+    )
+    await waitFor(() => {
+      expect(
+        screen.getAllByText("Beendigung der Phantasieverhältnisse")[0],
+      ).toBeInTheDocument()
+    })
+    await user.click(screen.getByLabelText("PR-05 hinzufügen"))
+    await user.click(
+      screen.getByRole("button", {
+        name: "PR-05 Beendigung der Phantasieverhältnisse aus Liste entfernen",
+      }),
+    )
+
+    // then
+    expect(
+      screen.queryByRole("button", {
+        name: "PR-05 Beendigung der Phantasieverhältnisse aus Liste entfernen",
+      }),
+    ).not.toBeInTheDocument()
+  })
+})

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -73,7 +73,8 @@ const vitestConfig = defineVitestConfig({
       "test/setup.ts",
     ],
     coverage: {
-      reporter: ["lcov"],
+      reporter: ["lcov", "text"],
+      reportOnFailure: true,
       exclude: [
         // Configuration and generated outputs
         "**/[.]**",


### PR DESCRIPTION
This PR ships unit tests for `FieldsOfLaw.vue`.

Why? You might ask. According to [Sonar](https://sonarcloud.io/component_measures?metric=coverage&selected=digitalservicebund_ris-frontend%3Asrc%2Fcomponents%2Ffield-of-law%2FFieldsOfLaw.vue&id=digitalservicebund_ris-frontend) the coverage for that file seems rather sufficient.

Yes but. 44% could be improved and the coverage is a false friend as it's only coming via `documentUnitCategories.spec.ts` <- `DocumentUnitCategories.vue` <- `DocumentUnitContentRelatedIndexing.vue` where `FieldsOfLaw.vue` is imported but not tested.

Therefore I added stubbing to get a clear view on the coverage.

According the changes in `frontend/vite.config.ts`:
- I added the `text` reporter only to view the coverage in the console (remove before merging)
- I needed to add `reportOnFailure` bc:
  - There is one unrelated unit test failing and
  - one within the domain ('Shows norms when required') which might point to a bug in the Tree (not further discussed).

What we can observe here is, that when running `npm run coverage` the coverage _drops_ to: ` FieldsOfLaw.vue                 |   16.93 |     92.3 |      75 |   16.93 | 1-182` with a very weird line coverage that is more than suspicious.

You can run `npx vite preview --outDir coverage/lcov-report` and open `http://localhost:3000` to get a html rendering (Just adding for completeness of the description - I am sure you are familiar).

Here we are. That is the problem. I have no idea so far how to fix it. Do you?

Interestingly I have the following observations to share:

When you run `npm i -D @vitest/coverage-istanbul@3.0.9` and change the `coverage.provider` to `istanbul` in the `vite.config.ts` the problem is fixed (After deleting `LinkElement.vue` which I [raised](https://digitalservicebund.slack.com/archives/C04C8MEGUBX/p1743152499765989) some time ago). But I am not suggesting a change as this would be a major shift. Just an observation.

Upgradig all vitest packages to 3.1.1 did not solve it.

To make it even more weird: Set row 39 to `describe.skip("FieldsOfLaw", () => {` and watch that coverage is up to incredibly 100%.