### PR TITLE
Run cron jobs in Berlin timezone

### DIFF
--- a/backend/src/main/java/de/bund/digitalservice/ris/caselaw/adapter/DatabaseDuplicateCheckService.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/caselaw/adapter/DatabaseDuplicateCheckService.java
@@ -63,8 +63,7 @@ public class DatabaseDuplicateCheckService implements DuplicateCheckService {
     }
   }
 
-  // Runs every night at 05:05:10
-  @Scheduled(cron = "10 5 5 * * *")
+  @Scheduled(cron = "10 5 5 * * *", zone = "Europe/Berlin")
   @SchedulerLock(name = "duplicate-check-job", lockAtMostFor = "PT15M")
   @Transactional
   @Override

--- a/backend/src/main/java/de/bund/digitalservice/ris/caselaw/adapter/PortalPublicationJobService.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/caselaw/adapter/PortalPublicationJobService.java
@@ -29,8 +29,8 @@ public class PortalPublicationJobService {
   //                      ↓ hour (0-23)
   //                    ↓ minute (0-59)
   //                 ↓ second (0-59)
-  // Default:        0 30 2 * * * (After migration: CET: 4:30)
-  @Scheduled(cron = "0 30 2 * * *")
+  // Default:        0 30 4 * * * (After migration: 4:30)
+  @Scheduled(cron = "0 30 4 * * *", zone = "Europe/Berlin")
   @SchedulerLock(name = "nightly-changelog-publish")
   public void publishNightlyChangelog() {
     try {

--- a/backend/src/main/java/de/bund/digitalservice/ris/caselaw/adapter/PrototypePortalPublicationService.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/caselaw/adapter/PrototypePortalPublicationService.java
@@ -51,8 +51,8 @@ public class PrototypePortalPublicationService extends CommonPortalPublicationSe
   //                      ↓ hour (0-23)
   //                    ↓ minute (0-59)
   //                 ↓ second (0-59)
-  // Default:        0 30 3 * * * (After migration: CET: 5:30)
-  @Scheduled(cron = "0 30 3 * * *")
+  // Default:        0 30 5 * * * (After migration: 5:30)
+  @Scheduled(cron = "0 30 5 * * *", zone = "Europe/Berlin")
   @SchedulerLock(name = "portal-publication-diff-job", lockAtMostFor = "PT15M")
   public void logPortalPublicationSanityCheck() {
     List<String> portalBucketDocumentNumbers =


### PR DESCRIPTION
To reduce mental load and time shift because of daylight saving time, we use Berlin timezone instead of UTC for all cron jobs.