### PR TITLE
Check for invalid doc units in cron job

### DIFF
--- a/backend/src/main/java/de/bund/digitalservice/ris/caselaw/adapter/DatabaseDocumentUnitConsistencyService.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/caselaw/adapter/DatabaseDocumentUnitConsistencyService.java
@@ -1,0 +1,59 @@
+package de.bund.digitalservice.ris.caselaw.adapter;
+
+import de.bund.digitalservice.ris.caselaw.adapter.database.jpa.DatabaseDocUnitConsistencyRepository;
+import jakarta.transaction.Transactional;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+@Service
+@Slf4j
+public class DatabaseDocumentUnitConsistencyService {
+  private final DatabaseDocUnitConsistencyRepository consistencyRepository;
+
+  public DatabaseDocumentUnitConsistencyService(
+      DatabaseDocUnitConsistencyRepository consistencyRepository) {
+    this.consistencyRepository = consistencyRepository;
+  }
+
+  /**
+   * Both decision and pending_proceeding inherit from documentation_unit. It is not possible to
+   * define foreign key constraints to ensure there are no documentation units without either a
+   * decision or pending proceeding. This illegal state leads to JPA errors when loading such
+   * entities.
+   *
+   * <p>If such an error is logged, the corresponding documentation units must be manually deleted.
+   */
+  @Scheduled(cron = "20 23 5 * * *", zone = "Europe/Berlin")
+  @SchedulerLock(name = "doc-unit-inheritance-consistency", lockAtMostFor = "PT5M")
+  @Transactional
+  public void checkInheritanceConsistency() {
+    try {
+      List<DocumentationUnitIdentifier> invalidDocUnits =
+          this.consistencyRepository.findDocUnitsWithoutDecisionOrPendingProceeding();
+      if (!invalidDocUnits.isEmpty()) {
+        String docNumbers =
+            invalidDocUnits.stream()
+                .map(DocumentationUnitIdentifier::documentNumber)
+                .collect(Collectors.joining(", "));
+        String docIds =
+            invalidDocUnits.stream()
+                .map(DocumentationUnitIdentifier::id)
+                .map(UUID::toString)
+                .collect(Collectors.joining(", "));
+        log.error(
+            "Found documentation units without decision or pending proceeding. Please delete them manually. doc-nr's: [{}], ids: [{}]",
+            docNumbers,
+            docIds);
+      }
+    } catch (Exception e) {
+      log.error("Error while checking doc unit inheritance consistency", e);
+    }
+  }
+
+  public record DocumentationUnitIdentifier(UUID id, String documentNumber) {}
+}

--- a/backend/src/main/java/de/bund/digitalservice/ris/caselaw/adapter/database/jpa/DatabaseDocUnitConsistencyRepository.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/caselaw/adapter/database/jpa/DatabaseDocUnitConsistencyRepository.java
@@ -1,0 +1,26 @@
+package de.bund.digitalservice.ris.caselaw.adapter.database.jpa;
+
+import de.bund.digitalservice.ris.caselaw.adapter.DatabaseDocumentUnitConsistencyService;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface DatabaseDocUnitConsistencyRepository
+    extends JpaRepository<DocumentationUnitDTO, UUID> {
+
+  @Query(
+      nativeQuery = true,
+      value =
+          """
+SELECT documentation_unit.id, documentation_unit.document_number
+FROM incremental_migration.documentation_unit documentation_unit
+         LEFT JOIN incremental_migration.decision decision ON documentation_unit.id = decision.id
+         LEFT JOIN incremental_migration.pending_proceeding pending_proceeding ON documentation_unit.id = pending_proceeding.id
+WHERE decision.id IS NULL AND pending_proceeding.id IS NULL
+""")
+  List<DatabaseDocumentUnitConsistencyService.DocumentationUnitIdentifier>
+      findDocUnitsWithoutDecisionOrPendingProceeding();
+}


### PR DESCRIPTION
RISDEV-6887
Logs error when documentation units without decision or pending_proceeding are found.