### PR TITLE
Fix performance for external search

### DIFF
--- a/backend/src/main/java/de/bund/digitalservice/ris/caselaw/adapter/OAuthService.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/caselaw/adapter/OAuthService.java
@@ -11,6 +11,7 @@ import de.bund.digitalservice.ris.caselaw.domain.AuthService;
 import de.bund.digitalservice.ris.caselaw.domain.Documentable;
 import de.bund.digitalservice.ris.caselaw.domain.DocumentationOffice;
 import de.bund.digitalservice.ris.caselaw.domain.DocumentationUnit;
+import de.bund.digitalservice.ris.caselaw.domain.DocumentationUnitListItem;
 import de.bund.digitalservice.ris.caselaw.domain.DocumentationUnitService;
 import de.bund.digitalservice.ris.caselaw.domain.Procedure;
 import de.bund.digitalservice.ris.caselaw.domain.ProcedureService;
@@ -272,6 +273,14 @@ public class OAuthService implements AuthService {
         return false;
       }
     };
+  }
+
+  public boolean isDocUnitAssignedViaProcedure(DocumentationUnitListItem documentationUnit) {
+    Procedure procedure = documentationUnit.procedure();
+    Optional<OidcUser> user = getOidcUser();
+    return procedure != null
+        && user.isPresent()
+        && isProcedureAssignedToUser(procedure, user.get());
   }
 
   /**

--- a/backend/src/main/java/de/bund/digitalservice/ris/caselaw/adapter/transformer/DocumentationUnitListItemTransformer.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/caselaw/adapter/transformer/DocumentationUnitListItemTransformer.java
@@ -64,6 +64,8 @@ public class DocumentationUnitListItemTransformer {
         .documentationOffice(
             DocumentationOfficeTransformer.transformToDomain(
                 documentationUnitListItemDTO.getDocumentationOffice()))
+        .procedure(
+            ProcedureTransformer.transformToDomain(documentationUnitListItemDTO.getProcedure()))
         .source(
             documentationUnitListItemDTO.getSource().stream()
                 .map(

--- a/backend/src/main/java/de/bund/digitalservice/ris/caselaw/domain/AuthService.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/caselaw/domain/AuthService.java
@@ -20,4 +20,6 @@ public interface AuthService {
       DocumentationOffice creatingDocOffice,
       DocumentationOffice documentationOffice,
       Status status);
+
+  boolean isDocUnitAssignedViaProcedure(DocumentationUnitListItem documentationUnit);
 }

--- a/backend/src/main/java/de/bund/digitalservice/ris/caselaw/domain/DocumentationUnitListItem.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/caselaw/domain/DocumentationUnitListItem.java
@@ -46,6 +46,7 @@ public record DocumentationUnitListItem(
     String source,
     DocumentationOffice creatingDocumentationOffice,
     DocumentationOffice documentationOffice,
+    Procedure procedure,
     String note,
     Boolean isDeletable,
     Boolean isEditable) {}

--- a/backend/src/main/java/de/bund/digitalservice/ris/caselaw/domain/DocumentationUnitService.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/caselaw/domain/DocumentationUnitService.java
@@ -281,7 +281,7 @@ public class DocumentationUnitService {
         .isDeletable(hasWriteAccess && isInternalUser)
         .isEditable(
             (hasWriteAccess
-                && (isInternalUser || authService.isAssignedViaProcedure().apply(listItem.uuid()))))
+                && (isInternalUser || authService.isDocUnitAssignedViaProcedure(listItem))))
         .build();
   }
 


### PR DESCRIPTION
RISDEV-5686
When external users search for doc units, every doc unit is loaded from the database again. Now we check on the already loaded doc unit entities in memory.