### PR TITLE
Fixed 'Mit Normen' status was not preserved

### DIFF
--- a/frontend/src/components/field-of-law/FieldsOfLaw.vue
+++ b/frontend/src/components/field-of-law/FieldsOfLaw.vue
@@ -17,7 +17,7 @@ import StringsUtil from "@/utils/stringsUtil"
 type FieldOfLawTreeType = InstanceType<typeof FieldOfLawTree>
 const treeRef = useTemplateRef<FieldOfLawTreeType>("treeRef")
 
-const showNorms = ref(false)
+const showNorms = ref<boolean | undefined>()
 const nodeOfInterest = ref<FieldOfLaw | undefined>(undefined)
 const isResetButtonVisible = ref(false)
 const description = ref("")
@@ -74,7 +74,8 @@ async function submitSearch(page: number) {
     if (results.value?.[0]) {
       nodeOfInterest.value = results.value[0]
     }
-    showNorms.value = !!norm.value
+    showNorms.value ??= !!norm.value // Show norms searched for the first time
+
     isResetButtonVisible.value = true
   } else {
     currentPage.value = undefined
@@ -206,7 +207,7 @@ function updateInputMethod(value: InputMethod) {
         :node-of-interest="nodeOfInterest"
         :search-results="results"
         :selected-nodes="selectedNodes"
-        :show-norms="showNorms"
+        :show-norms="showNorms || false"
         @linked-field:select="setNodeOfInterest"
         @node-of-interest:reset="removeNodeOfInterest"
         @node:add="addFieldOfLaw"

--- a/frontend/test/components/fieldOfLaw/fieldsOfLaw.spec.ts
+++ b/frontend/test/components/fieldOfLaw/fieldsOfLaw.spec.ts
@@ -443,6 +443,36 @@ describe("FieldsOfLaw", () => {
     })
   })
 
+  it("Shows norms by default when searching for norms and preserves user toggled checkbox state after re-search", async () => {
+    // given
+    const { user } = renderComponent()
+
+    // when
+    await user.click(screen.getByRole("button", { name: "Sachgebiete" }))
+    await user.click(
+      screen.getByRole("radio", { name: "Sachgebietsuche auswählen" }),
+    )
+    await user.type(screen.getByLabelText("Sachgebietsnorm"), "§ 99")
+
+    await user.click(
+      screen.getByRole("button", { name: "Sachgebietssuche ausführen" }),
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText("§ 99")).toBeInTheDocument()
+    })
+
+    await user.click(screen.getAllByRole("checkbox")[0])
+
+    await user.click(
+      screen.getByRole("button", { name: "Sachgebietssuche ausführen" }),
+    )
+    // then
+    await waitFor(() => {
+      expect(screen.queryByText("§ 99")).not.toBeInTheDocument()
+    })
+  })
+
   it("Shows warning when backend responds with error message", async () => {
     // given
     vi.spyOn(FieldOfLawService, "searchForFieldsOfLaw").mockImplementation(


### PR DESCRIPTION
RISDEV-8355

Norms should be shown by default when searching for norms. After that, the 'Mit Normen' status should be preserved on research