### PR TITLE
Send structured JSON logs to Loki

### DIFF
--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -47,7 +47,10 @@ server:
         max-age: 43200 # 12*60*60
         http-only: false
       timeout: 43200 # 12*60*60
-#logging:
+logging:
+  structured:
+    format:
+      console: logstash
 #  level:
 #    org.springframework: DEBUG
 #    org.hibernate.SQL: DEBUG

--- a/backend/src/main/resources/logback-spring.xml
+++ b/backend/src/main/resources/logback-spring.xml
@@ -4,10 +4,14 @@
         <include resource="org/springframework/boot/logging/logback/base.xml"/>
     </springProfile>
     <springProfile name="staging,production,uat">
-        <include resource="org/springframework/boot/logging/logback/base.xml"/>
+        <!-- The structured format value from application.yaml is not available here. Unclear why. -->
+        <property name="CONSOLE_LOG_STRUCTURED_FORMAT"
+                  value="${CONSOLE_LOG_STRUCTURED_FORMAT:-logstash}"/>
+        <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
+        <include resource="org/springframework/boot/logging/logback/structured-console-appender.xml"/>
         <appender name="SENTRY" class="io.sentry.logback.SentryAppender" />
         <root level="INFO">
-            <!-- <appender-ref ref="LOKI" /> -->.
+            <appender-ref ref="CONSOLE" />
             <appender-ref ref="SENTRY"/>
         </root>
     </springProfile>


### PR DESCRIPTION
RISDEV-8509
With this, stack traces will not span multiple lines and logs can be queried by structured fields.

This has already been deployed to all envs and then reverted by commit 2685920c50fb0d38b884ee37bab8a00fea8d0005.