### PR TITLE
Fix duplicated elements LDML bug

### DIFF
--- a/backend/src/main/java/de/bund/digitalservice/ris/caselaw/adapter/caselawldml/AknMultipleBlock.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/caselaw/adapter/caselawldml/AknMultipleBlock.java
@@ -18,7 +18,6 @@ public class AknMultipleBlock {
   // A Map is used with @XmlElement added to a helper getter/setter to facilitate easier use.
   @XmlTransient private Map<String, AknBlock> blocks = new LinkedHashMap<>();
 
-  @XmlElement(name = "block", namespace = CaseLawLdml.AKN_NS)
   public void setJaxbBlocks(List<AknBlock> blocks) {
     for (AknBlock block : blocks) {
       this.blocks.put(block.getName(), block);

--- a/backend/src/main/java/de/bund/digitalservice/ris/caselaw/adapter/caselawldml/JaxbHtml.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/caselaw/adapter/caselawldml/JaxbHtml.java
@@ -7,14 +7,10 @@ import jakarta.xml.bind.annotation.XmlRootElement;
 import java.util.List;
 import java.util.Objects;
 import lombok.AllArgsConstructor;
-import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-@Getter
-@Setter
 @NoArgsConstructor
 @AllArgsConstructor
 @XmlRootElement


### PR DESCRIPTION
When generating LDML, we get an error, because multiple elements have the same XML annotations. We assume this was somehow caused by the Gradle 9 / Lombok update.