### PR TITLE
Reload doc unit for status update after publish

### DIFF
--- a/frontend/src/components/publication/PublicationActions.vue
+++ b/frontend/src/components/publication/PublicationActions.vue
@@ -27,7 +27,7 @@ const publishDocUnit = async () => {
     store.documentUnit!.uuid!,
   )
   docUnitPublicationError.value = error ?? null
-  await store.updateDocumentUnit()
+  await store.loadDocumentUnit(decision.value.documentNumber)
   isPublishing.value = false
 }
 

--- a/frontend/test/components/publication/publicationActions.spec.ts
+++ b/frontend/test/components/publication/publicationActions.spec.ts
@@ -260,7 +260,7 @@ describe("PublicationActions", () => {
     it("should update the status", async () => {
       const store = mockDocUnitStore(PortalPublicationStatus.UNPUBLISHED)
       await renderComponent({ isPublishable: true })
-      const updateDocUnitSpy = vi.spyOn(store, "updateDocumentUnit")
+      const loadDocUnitSpy = vi.spyOn(store, "loadDocumentUnit")
       vi.spyOn(
         publishDocumentationUnitService,
         "publishDocument",
@@ -273,7 +273,7 @@ describe("PublicationActions", () => {
         screen.getByRole("button", { name: "Veröffentlichen" }),
       )
 
-      expect(updateDocUnitSpy).toHaveBeenCalledOnce()
+      expect(loadDocUnitSpy).toHaveBeenCalledOnce()
       expect(screen.getByText("Veröffentlicht")).toBeVisible()
     })
 


### PR DESCRIPTION
RISDEV-8456
Because the backend publication action does not trigger a PATCH update and with that a version update, the partial loading does not update the doc unit. We need to fully re-load the doc unit.