### PR TITLE
Log frontend access logs as JSON

### DIFF
--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -1,11 +1,57 @@
+# Map to exclude health check user agents from logging
+map $http_user_agent $is_health_check_agent {
+    default 0;
+    ~*SentryUptimeBot 1;
+    ~*kube-probe 1;
+}
+map $request_uri $is_root_path {
+    default 0;
+    / 1;
+}
+map $status $is_ok {
+    default 0;
+    200 1;
+}
+map "${is_health_check_agent}${is_root_path}${is_ok}" $is_non_health_check {
+    default 1;     # Log by default
+    "111" 0;       # Don't log if kube or Sentry agent successfully request root path "/"
+}
+
+log_format json_combined escape=json
+'{'
+    '"timestamp": "$time_iso8601",'
+    '"status": $status,'
+    '"method": "$request_method",'
+    '"path": "$uri",'
+    '"host": "$host",'
+    '"scheme": "$scheme",'
+    '"args": "$args",'
+    '"length": $request_length,'
+    '"duration": $request_time,'
+    '"user_agent": "$http_user_agent",'
+    '"session_id": "$session_id"'
+'}';
+
 server {
     listen       8081;
     server_name  localhost;
+
+    # Enable JSON access logging for non-health check agents
+    access_log /var/log/nginx/access.log json_combined if=$is_non_health_check;
+
+    set $session_id $request_id;
+    if ($cookie_SESSION_ID) {
+        # The current session will be reused for 12 hours
+        set $session_id $cookie_SESSION_ID;
+    }
+
 
     location / {
         root /var/lib/nginx/html;
         index index.html index.htm;
         try_files $uri $uri/ /index.html;
+        # Session-Id (only for logging) expires after 12 hours
+        add_header Set-Cookie "session_id=$session_id; Path=/; Max-Age=43200; HttpOnly; SameSite=Strict; Secure" always;
         add_header X-Frame-Options SAMEORIGIN always;
         add_header X-Content-Type-Options nosniff always;
         add_header Content-Security-Policy "default-src 'self'; img-src 'self' data:; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-eval'; connect-src 'self' *.sentry.io data:" always;


### PR DESCRIPTION
RISDEV-8509
This filters out health checks and adds a 12h session id cookie, that will help to trace user sessions in our logs.