### PR TITLE
Log e2e test name via custom header

### DIFF
--- a/backend/src/main/java/de/bund/digitalservice/ris/caselaw/config/MdcLoggingFilter.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/caselaw/config/MdcLoggingFilter.java
@@ -29,6 +29,7 @@ class MdcLoggingFilter extends OncePerRequestFilter {
     try {
       setSessionIdFromCookie(request);
       setRequestIdFromHeader(request, response);
+      setTestNameFromHeader(request);
       setUserGroupFromAuthentication();
     } catch (Exception e) {
       logger.error("Failed to set MDC context", e);
@@ -65,6 +66,13 @@ class MdcLoggingFilter extends OncePerRequestFilter {
         Optional.ofNullable(request.getHeader("X-Request-ID")).orElse(UUID.randomUUID().toString());
     MDC.put("request_id", requestId);
     response.setHeader("X-Request-ID", requestId);
+  }
+
+  private void setTestNameFromHeader(@NotNull HttpServletRequest request) {
+    String testName = request.getHeader("X-Test-Name");
+    if (testName != null) {
+      MDC.put("test_name", testName);
+    }
   }
 
   /**

--- a/backend/src/main/java/de/bund/digitalservice/ris/caselaw/config/RequestLoggingFilterConfig.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/caselaw/config/RequestLoggingFilterConfig.java
@@ -1,0 +1,20 @@
+package de.bund.digitalservice.ris.caselaw.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.filter.CommonsRequestLoggingFilter;
+
+@Configuration
+public class RequestLoggingFilterConfig {
+
+  @Bean
+  public CommonsRequestLoggingFilter logFilter() {
+    CommonsRequestLoggingFilter filter = new CommonsRequestLoggingFilter();
+    filter.setIncludeQueryString(true);
+    filter.setIncludeClientInfo(true);
+    filter.setIncludePayload(false);
+    filter.setMaxPayloadLength(10000);
+    filter.setIncludeHeaders(false);
+    return filter;
+  }
+}

--- a/backend/src/main/resources/application-staging.yaml
+++ b/backend/src/main/resources/application-staging.yaml
@@ -12,6 +12,10 @@ spring:
       host: redis
       username: redis
 
+logging:
+  level:
+    org.springframework.web.filter.CommonsRequestLoggingFilter: DEBUG
+
 database:
   seed: true
 

--- a/backend/src/test/java/de/bund/digitalservice/ris/caselaw/config/MdcLoggingFilterTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/caselaw/config/MdcLoggingFilterTest.java
@@ -100,6 +100,25 @@ class MdcLoggingFilterTest {
   }
 
   @Test
+  void shouldLogTestNameFromHeader() throws Exception {
+
+    String testName =
+        "caselaw/decision/categories/collective-agreements.spec.ts > Collective Agreements (Tarifvertrag) > saving and exporting collective agreement";
+    request.addHeader("x-test-name", testName);
+
+    // MDC will be cleared after filter chain, so we need to check inside the chain
+    FilterChain spyingChain =
+        (req, res) -> {
+          assertThat(MDC.get("test_name")).isEqualTo(testName);
+          assertThat(MDC.getCopyOfContextMap()).hasSize(2);
+        };
+
+    filter.doFilter(request, response, spyingChain);
+
+    assertThat(MDC.getCopyOfContextMap()).isNull();
+  }
+
+  @Test
   void shouldExtractDocOfficeWhenLoggedIn() throws Exception {
 
     OidcUser oidcUser = mock(OidcUser.class);

--- a/frontend/test/e2e/caselaw/fixtures.ts
+++ b/frontend/test/e2e/caselaw/fixtures.ts
@@ -95,6 +95,15 @@ async function deleteWithRetry(
 }
 
 export const caselawTest = test.extend<MyFixtures & MyOptions>({
+  context: async ({ browser }, use, testInfo) => {
+    const context = await browser.newContext()
+    // The current test name will be added to all logs, see MdcLoggingFilter.java
+    await context.setExtraHTTPHeaders({
+      "X-Test-Name": testInfo.titlePath.join(" > "),
+    })
+    await use(context)
+    await context.close()
+  },
   documentNumber: async ({ request, context }, use) => {
     const cookies = await context.cookies()
     const csrfToken = cookies.find((cookie) => cookie.name === "XSRF-TOKEN")


### PR DESCRIPTION
Playwright adds a custom header with the test name that will be logged by our backend.