### PR TITLE
Reduce backend access log volume

### DIFF
--- a/backend/src/main/java/de/bund/digitalservice/ris/caselaw/config/CaselawRequestLoggingFilter.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/caselaw/config/CaselawRequestLoggingFilter.java
@@ -1,0 +1,20 @@
+package de.bund.digitalservice.ris.caselaw.config;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.jetbrains.annotations.NotNull;
+import org.springframework.web.filter.CommonsRequestLoggingFilter;
+
+public class CaselawRequestLoggingFilter extends CommonsRequestLoggingFilter {
+  @Override
+  protected boolean shouldLog(@NotNull HttpServletRequest request) {
+    return super.shouldLog(request)
+        && request.getRequestURI() != null
+        // Exclude health checks
+        && !request.getRequestURI().startsWith("/actuator");
+  }
+
+  @Override
+  protected void afterRequest(@NotNull HttpServletRequest request, @NotNull String message) {
+    // No op: Do not log a second time after the request
+  }
+}

--- a/backend/src/main/java/de/bund/digitalservice/ris/caselaw/config/RequestLoggingFilterConfig.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/caselaw/config/RequestLoggingFilterConfig.java
@@ -2,19 +2,19 @@ package de.bund.digitalservice.ris.caselaw.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.web.filter.CommonsRequestLoggingFilter;
 
 @Configuration
 public class RequestLoggingFilterConfig {
 
   @Bean
-  public CommonsRequestLoggingFilter logFilter() {
-    CommonsRequestLoggingFilter filter = new CommonsRequestLoggingFilter();
+  public CaselawRequestLoggingFilter logFilter() {
+    CaselawRequestLoggingFilter filter = new CaselawRequestLoggingFilter();
     filter.setIncludeQueryString(true);
-    filter.setIncludeClientInfo(true);
+    filter.setIncludeClientInfo(false);
     filter.setIncludePayload(false);
     filter.setMaxPayloadLength(10000);
     filter.setIncludeHeaders(false);
+    filter.setBeforeMessagePrefix("Request [");
     return filter;
   }
 }

--- a/backend/src/main/resources/application-staging.yaml
+++ b/backend/src/main/resources/application-staging.yaml
@@ -14,7 +14,7 @@ spring:
 
 logging:
   level:
-    org.springframework.web.filter.CommonsRequestLoggingFilter: DEBUG
+    de.bund.digitalservice.ris.caselaw.config.CaselawRequestLoggingFilter: DEBUG
 
 database:
   seed: true


### PR DESCRIPTION

Only log beginning of request and filter out health checks