### PR TITLE
Prohibit deletion of published doc units

### DIFF
--- a/backend/src/main/java/de/bund/digitalservice/ris/caselaw/adapter/DocumentationUnitController.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/caselaw/adapter/DocumentationUnitController.java
@@ -342,7 +342,7 @@ public class DocumentationUnitController {
       var str = service.deleteByUuid(uuid);
       return ResponseEntity.status(HttpStatus.OK).body(str);
     } catch (DocumentationUnitNotExistsException | DocumentationUnitDeletionException ex) {
-      return ResponseEntity.internalServerError().body(ex.getMessage());
+      return ResponseEntity.badRequest().body(ex.getMessage());
     }
   }
 

--- a/backend/src/main/java/de/bund/digitalservice/ris/caselaw/adapter/PortalPublicationService.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/caselaw/adapter/PortalPublicationService.java
@@ -83,6 +83,11 @@ public class PortalPublicationService {
     try {
       DocumentationUnit documentationUnit =
           documentationUnitRepository.findByUuid(documentationUnitId);
+      log.atInfo()
+          .setMessage("Publishing doc unit...")
+          .addKeyValue("documentNumber", documentationUnit.documentNumber())
+          .addKeyValue("id", documentationUnitId)
+          .log();
       var result = publishToBucket(documentationUnit);
       uploadChangelogWithdrawOnFailure(documentationUnit, result);
       updatePortalPublicationStatus(documentationUnit, PortalPublicationStatus.PUBLISHED, user);
@@ -147,6 +152,11 @@ public class PortalPublicationService {
       throws DocumentationUnitNotExistsException {
     try {
       var documentationUnit = documentationUnitRepository.findByUuid(documentationUnitId);
+      log.atInfo()
+          .setMessage("Withdrawing doc unit...")
+          .addKeyValue("documentNumber", documentationUnit.documentNumber())
+          .addKeyValue("id", documentationUnitId)
+          .log();
       var result = withdrawDocumentationUnit(documentationUnit.documentNumber());
       uploadDeletionChangelog(result.deletedPaths());
       updatePortalPublicationStatus(documentationUnit, PortalPublicationStatus.WITHDRAWN, user);

--- a/backend/src/main/java/de/bund/digitalservice/ris/caselaw/domain/DocumentationUnitService.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/caselaw/domain/DocumentationUnitService.java
@@ -579,6 +579,13 @@ public class DocumentationUnitService {
   public String deleteByUuid(UUID documentationUnitId) throws DocumentationUnitNotExistsException {
 
     DocumentationUnit docUnit = getByUuid(documentationUnitId);
+
+    log.atInfo()
+        .setMessage("Deleting doc unit...")
+        .addKeyValue("documentNumber", docUnit.documentNumber())
+        .addKeyValue("id", documentationUnitId)
+        .log();
+
     Map<RelatedDocumentationType, Long> relatedEntities =
         repository.getAllRelatedDocumentationUnitsByDocumentNumber(docUnit.documentNumber());
 
@@ -593,6 +600,16 @@ public class DocumentationUnitService {
 
       throw new DocumentationUnitDeletionException(
           "Die Dokumentationseinheit konnte nicht gelöscht werden, da", relatedEntities);
+    }
+
+    if (PortalPublicationStatus.PUBLISHED.equals(docUnit.portalPublicationStatus())) {
+      log.atInfo()
+          .setMessage("Doc unit deletion was prohibited because it is published in the portal.")
+          .addKeyValue("documentNumber", docUnit.documentNumber())
+          .addKeyValue("docUnitId", documentationUnitId)
+          .log();
+      throw new DocumentationUnitDeletionException(
+          "Die Dokumentationseinheit konnte nicht gelöscht werden, da Sie im Portal veröffentlicht ist.\nSie muss zuerst zurückgezogen werden.");
     }
 
     log.debug("Deleting DocumentationUnitDTO " + documentationUnitId);


### PR DESCRIPTION
RISDEV-8456
If a published doc unit were to be deleted, it would not be possible to withdraw it from the portal.