### PR TITLE
Remove navigation from auth setup test

### DIFF
--- a/frontend/test/e2e/caselaw/auth.setup.ts
+++ b/frontend/test/e2e/caselaw/auth.setup.ts
@@ -31,7 +31,6 @@ function authenticateUser(user: {
     await page.fill("#password", user.password)
     await page.locator("input#kc-login").click()
 
-    await page.goto(process.env.E2E_BASE_URL ?? "http://127.0.0.1")
     // Caution: The test needs to wait for the page to load completely
     // Otherwise, the location cookie might not be unset and redirect to '/' on page load
     await expect(page.getByText("Starten Sie die Suche")).toBeVisible()


### PR DESCRIPTION
When Bare.ID login succeeds, we will be automatically redirected. There is no need to navigate manually. (The navigation might happen before the login has completed.)