### PR TITLE
Portal publication fixes

### DIFF
--- a/backend/src/test/java/de/bund/digitalservice/ris/caselaw/adapter/PortalPublicationServiceTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/caselaw/adapter/PortalPublicationServiceTest.java
@@ -492,6 +492,9 @@ class PortalPublicationServiceTest {
         subject.withdrawDocumentationUnit(testDocumentNumber);
 
         verify(caseLawBucket).delete(withPrefix(testDocumentNumber));
+        verify(documentationUnitRepository)
+            .updatePortalPublicationStatus(
+                testDocumentUnit.uuid(), PortalPublicationStatus.WITHDRAWN);
       }
 
       @Test
@@ -503,6 +506,9 @@ class PortalPublicationServiceTest {
         assertThatExceptionOfType(PublishException.class)
             .isThrownBy(() -> subject.withdrawDocumentationUnit(testDocumentNumber))
             .withMessageContaining("Could not delete LDML from bucket.");
+        verify(documentationUnitRepository, never())
+            .updatePortalPublicationStatus(
+                testDocumentUnit.uuid(), PortalPublicationStatus.WITHDRAWN);
       }
     }
 

--- a/backend/src/test/java/de/bund/digitalservice/ris/caselaw/adapter/PortalPublicationServiceTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/caselaw/adapter/PortalPublicationServiceTest.java
@@ -483,7 +483,9 @@ class PortalPublicationServiceTest {
     @Nested
     class WithdrawDocumentationUnit {
       @Test
-      void withdraw_shouldDeleteFromBucket() {
+      void withdraw_shouldDeleteFromBucket() throws DocumentationUnitNotExistsException {
+        when(documentationUnitRepository.findByDocumentNumber(testDocumentUnit.documentNumber()))
+            .thenReturn(testDocumentUnit);
         when(caseLawBucket.getAllFilenamesByPath(testDocumentNumber + "/"))
             .thenReturn(List.of(withPrefix(testDocumentNumber)));
 

--- a/backend/src/test/java/de/bund/digitalservice/ris/caselaw/integration/tests/PrototypePortalPublicationJobIntegrationTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/caselaw/integration/tests/PrototypePortalPublicationJobIntegrationTest.java
@@ -184,7 +184,8 @@ class PrototypePortalPublicationJobIntegrationTest extends BaseIntegrationTest {
             repository.findAll().stream()
                 .map(DocumentationUnitDTO::getPortalPublicationStatus)
                 .toList())
-        .isEqualTo(List.of(PortalPublicationStatus.PUBLISHED, PortalPublicationStatus.WITHDRAWN));
+        .containsExactlyInAnyOrder(
+            PortalPublicationStatus.PUBLISHED, PortalPublicationStatus.WITHDRAWN);
   }
 
   @Test

--- a/backend/src/test/java/de/bund/digitalservice/ris/caselaw/integration/tests/PrototypePortalPublicationJobIntegrationTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/caselaw/integration/tests/PrototypePortalPublicationJobIntegrationTest.java
@@ -27,6 +27,7 @@ import de.bund.digitalservice.ris.caselaw.adapter.database.jpa.PortalPublication
 import de.bund.digitalservice.ris.caselaw.adapter.database.jpa.PortalPublicationJobRepository;
 import de.bund.digitalservice.ris.caselaw.adapter.transformer.ldml.ReducedLdmlTransformer;
 import de.bund.digitalservice.ris.caselaw.domain.DocumentationOffice;
+import de.bund.digitalservice.ris.caselaw.domain.PortalPublicationStatus;
 import de.bund.digitalservice.ris.caselaw.domain.PublicationJobStatus;
 import de.bund.digitalservice.ris.caselaw.domain.PublicationJobType;
 import java.io.IOException;
@@ -179,6 +180,11 @@ class PrototypePortalPublicationJobIntegrationTest extends BaseIntegrationTest {
 
     assertThat(portalPublicationJobRepository.findAll())
         .allMatch(job -> job.getPublicationJobStatus() == SUCCESS);
+    assertThat(
+            repository.findAll().stream()
+                .map(DocumentationUnitDTO::getPortalPublicationStatus)
+                .toList())
+        .isEqualTo(List.of(PortalPublicationStatus.PUBLISHED, PortalPublicationStatus.WITHDRAWN));
   }
 
   @Test

--- a/frontend/src/components/publication/PublicationActions.vue
+++ b/frontend/src/components/publication/PublicationActions.vue
@@ -121,7 +121,7 @@ const lastPublishedAt = computed(() => {
         </div>
       </div>
 
-      <div v-if="isPublished || isWithdrawn" class="flex flex-row gap-8">
+      <div v-if="isPublished" class="flex flex-row gap-8">
         <IconInfoOutline class="text-grey-900" />
         <p>
           Das Hochladen der Stammdaten und der Informationen im Portal-Tab

--- a/frontend/src/components/publication/PublicationActions.vue
+++ b/frontend/src/components/publication/PublicationActions.vue
@@ -125,7 +125,7 @@ const lastPublishedAt = computed(() => {
         <IconInfoOutline class="text-grey-900" />
         <p>
           Das Hochladen der Stammdaten und der Informationen im Portal-Tab
-          „Details“ dauert etwa 2 Minuten.
+          „Details“ dauert ungefähr 5 Minuten.
         </p>
       </div>
       <div

--- a/frontend/test/components/publication/publicationActions.spec.ts
+++ b/frontend/test/components/publication/publicationActions.spec.ts
@@ -622,7 +622,7 @@ describe("PublicationActions", () => {
       ).not.toBeInTheDocument()
     })
 
-    it("shows hint for withdrawn doc unit after successful withdraw", async () => {
+    it("shows no hint for withdrawn doc unit after successful withdraw", async () => {
       mockDocUnitStore(PortalPublicationStatus.PUBLISHED)
       withdrawMock.mockResolvedValue({
         status: 200,
@@ -635,10 +635,8 @@ describe("PublicationActions", () => {
       )
       await flushPromises()
       expect(
-        screen.getByText(
-          "Das Hochladen der Stammdaten und der Informationen im Portal-Tab „Details“ dauert etwa 2 Minuten.",
-        ),
-      ).toBeInTheDocument()
+        screen.queryByText(/Das Hochladen der Stammdaten.*2 Minuten/),
+      ).not.toBeInTheDocument()
     })
   })
 })

--- a/frontend/test/components/publication/publicationActions.spec.ts
+++ b/frontend/test/components/publication/publicationActions.spec.ts
@@ -155,7 +155,7 @@ describe("PublicationActions", () => {
       await flushPromises()
       expect(
         screen.getByText(
-          "Das Hochladen der Stammdaten und der Informationen im Portal-Tab „Details“ dauert etwa 2 Minuten.",
+          "Das Hochladen der Stammdaten und der Informationen im Portal-Tab „Details“ dauert ungefähr 5 Minuten.",
         ),
       ).toBeInTheDocument()
     })

--- a/frontend/test/components/publication/publicationActions.spec.ts
+++ b/frontend/test/components/publication/publicationActions.spec.ts
@@ -137,7 +137,7 @@ describe("PublicationActions", () => {
       await renderComponent({ isPublishable: true, publicationWarnings: [] })
 
       expect(
-        screen.queryByText(/Das Hochladen der Stammdaten.*2 Minuten/),
+        screen.queryByText(/Das Hochladen der Stammdaten.*5 Minuten/),
       ).not.toBeInTheDocument()
     })
 
@@ -618,7 +618,7 @@ describe("PublicationActions", () => {
       await renderComponent({ isPublishable: true, publicationWarnings: [] })
 
       expect(
-        screen.queryByText(/Das Hochladen der Stammdaten.*2 Minuten/),
+        screen.queryByText(/Das Hochladen der Stammdaten.*5 Minuten/),
       ).not.toBeInTheDocument()
     })
 
@@ -635,7 +635,7 @@ describe("PublicationActions", () => {
       )
       await flushPromises()
       expect(
-        screen.queryByText(/Das Hochladen der Stammdaten.*2 Minuten/),
+        screen.queryByText(/Das Hochladen der Stammdaten.*5 Minuten/),
       ).not.toBeInTheDocument()
     })
   })


### PR DESCRIPTION
Fixes: 

1. During nightly Delete job we didn't adjust the PortalPublicationStatus
2. We displayed a hint after withdrawing a document which should be hidden.
3. We assumed the portal link would work after 2 minutes but changed it to 5.