### PR TITLE
Clear process steps when assigning new docoffice

### DIFF
--- a/backend/src/main/java/de/bund/digitalservice/ris/caselaw/adapter/database/jpa/PostgresDocumentationUnitRepositoryImpl.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/caselaw/adapter/database/jpa/PostgresDocumentationUnitRepositoryImpl.java
@@ -565,6 +565,8 @@ public class PostgresDocumentationUnitRepositoryImpl implements DocumentationUni
 
     DocumentationUnitProcessStep currentDocunitProcessStepFromFrontend =
         documentationUnit.currentDocumentationUnitProcessStep();
+    List<DocumentationUnitProcessStep> docunitProcessStepsFromFrontend =
+        documentationUnit.processSteps();
     DocumentationUnitProcessStepDTO currentDocumentationUnitProcessStepDTOFromDB =
         documentationUnitDTO.getCurrentProcessStep();
 
@@ -593,7 +595,10 @@ public class PostgresDocumentationUnitRepositoryImpl implements DocumentationUni
       processStepChanged = true;
       DocumentationUnitProcessStepDTO newDocumentationUnitProcessStepDTO =
           createAndSaveNewProcessStep(
-              documentationUnitDTO, processStepDTO, currentDocunitProcessStepFromFrontend);
+              documentationUnitDTO,
+              processStepDTO,
+              currentDocunitProcessStepFromFrontend,
+              docunitProcessStepsFromFrontend);
 
       if (stepChanged) {
         String description =
@@ -683,7 +688,18 @@ public class PostgresDocumentationUnitRepositoryImpl implements DocumentationUni
   private DocumentationUnitProcessStepDTO createAndSaveNewProcessStep(
       DocumentationUnitDTO documentationUnitDTO,
       ProcessStepDTO processStepDTO,
-      DocumentationUnitProcessStep currentDocunitProcessStepFromFrontend) {
+      DocumentationUnitProcessStep currentDocunitProcessStepFromFrontend,
+      List<DocumentationUnitProcessStep> docunitProcessStepsFromFrontend) {
+
+    // when assigning a new doc office, all previous process steps are removed
+    boolean isOwnerChangeScenario =
+        (docunitProcessStepsFromFrontend != null
+            && docunitProcessStepsFromFrontend.isEmpty()
+            && "Neu".equals(processStepDTO.getName()));
+
+    if (isOwnerChangeScenario) {
+      documentationUnitDTO.getProcessSteps().clear();
+    }
 
     DocumentationUnitProcessStepDTO newDocumentationUnitProcessStepDTO =
         DocumentationUnitProcessStepDTO.builder()

--- a/backend/src/main/java/de/bund/digitalservice/ris/caselaw/domain/DocumentationUnitService.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/caselaw/domain/DocumentationUnitService.java
@@ -846,6 +846,7 @@ public class DocumentationUnitService {
       // Procedures need to be unassigned as they are linked to the previous documentation Office
       repository.unassignProcedures(decision.uuid());
       repository.saveDocumentationOffice(documentationUnitId, documentationOffice, user);
+
       decision =
           decision.toBuilder()
               .currentDocumentationUnitProcessStep(
@@ -860,6 +861,7 @@ public class DocumentationUnitService {
                                       new ProcessStepNotFoundException(
                                           "Process Step 'Neu' not found")))
                       .build())
+              .processSteps(List.of())
               .build();
       repository.saveProcessSteps(decision, user);
       return "The documentation office [%s] has been successfully assigned."

--- a/backend/src/test/java/de/bund/digitalservice/ris/caselaw/integration/tests/DocumentationUnitIntegrationTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/caselaw/integration/tests/DocumentationUnitIntegrationTest.java
@@ -2199,7 +2199,8 @@ class DocumentationUnitIntegrationTest extends BaseIntegrationTest {
 
   @Transactional
   @Test
-  void assignDocumentationOffice_withProcessStep_shouldAddProcessStepNeu() {
+  void
+      assignDocumentationOffice_withProcessStep_shouldEmptyPreviousProcessStepsAndAddProcessStepNeu() {
     // Arrange
     var bghDocOffice = documentationOfficeRepository.findByAbbreviation("BGH");
     var decisionBuilder =
@@ -2241,12 +2242,10 @@ class DocumentationUnitIntegrationTest extends BaseIntegrationTest {
               assertThat(response.getResponseBody())
                   .isEqualTo("The documentation office [BGH] has been successfully assigned.");
               var docUnit = repository.findById(documentationUnit.getId());
-              assertThat(docUnit.get().getProcessSteps()).size().isEqualTo(2);
+              assertThat(docUnit.get().getProcessSteps()).size().isEqualTo(1);
               assertThat(docUnit.get().getCurrentProcessStep().getProcessStep())
                   .isEqualTo(neuProcessStep);
-              assertThat(docUnit.get().getProcessSteps().get(0).getProcessStep())
-                  .isEqualTo(ersterfassungProcessStep);
-              assertThat(docUnit.get().getProcessSteps().get(1).getProcessStep())
+              assertThat(docUnit.get().getProcessSteps().getFirst().getProcessStep())
                   .isEqualTo(neuProcessStep);
             });
   }


### PR DESCRIPTION
RISDEV-9167
This logic applies when a document's Documentation Office is reassigned.

scenario 1: docoffice A assinging to docoffice B -> all previous process steps are cleared. This action deletes all underlying documentationUnitProcessStep data. For our history logs the loss of the documentationUnitProcessSteps is acceptable, because we only need these documentationUnitProcessSteps to retrieve the user data dynamically. As the process step change the history logs save a description like 'Schritt geändert: [from] -> [to]', which is hardcoded information in the description field and will therefore be there even though the underlying information is not there anymore. Only the user data can not be retrieved, but in this case it is fine, because the docoffice B is not allowed to see user information from docoffice A anyways, they will only see 'Person geändert'.

scenario 2: docoffice B assigns docunit back to docoffice A -> when assigning BACK to docoffice A, this information can not be restored, because the underlying documentationUnitProcessStep data is gone. Meaning, that we still do only show 'Person geändert', even though the user from docoffice A should be able to see the user information. We took this tradeoff, because this is a very rare edge case and to properly handle previous process steps for other docoffices after reassigning, we need to store the docoffice information seperately in the documentationUnitProcessStep and not in the user of the documentationUnitProcessStep. (Because the user will not always be there to provide that information).

This trade-off was made because this 'reassign back' scenario is a very rare edge case. The proper solution would require storing the documentation office information separately within the DocumentationUnitProcessStep entity to preserve history, which was deemed too much effort for this very edge case.