### PR TITLE
[RISDEV-9094] Save document before checking all text

### DIFF
--- a/frontend/src/components/text-check/DocumentationUnitTextCheckSummary.vue
+++ b/frontend/src/components/text-check/DocumentationUnitTextCheckSummary.vue
@@ -24,6 +24,7 @@ const selectedSuggestion = ref()
 
 const checkAll = async () => {
   if (store.documentUnit) {
+    await store.updateDocumentUnit()
     const response = await languageToolService.checkAll(store.documentUnit.uuid)
 
     errors.value = response.data?.suggestions

--- a/frontend/test/components/text-check/documentationUnitTextCheckSummary.spec.ts
+++ b/frontend/test/components/text-check/documentationUnitTextCheckSummary.spec.ts
@@ -1,0 +1,54 @@
+import { createTestingPinia } from "@pinia/testing"
+import { render } from "@testing-library/vue"
+import { setActivePinia } from "pinia"
+import { describe } from "vitest"
+import DocumentationUnitTextCheckSummary from "@/components/text-check/DocumentationUnitTextCheckSummary.vue"
+import { Decision } from "@/domain/decision"
+import languageToolService from "@/services/textCheckService"
+import { useDocumentUnitStore } from "@/stores/documentUnitStore"
+
+const checkAllResponse = {
+  status: 200,
+  data: { suggestions: [], categoryTypes: [], totalTextCheckErrors: 0 },
+  error: undefined,
+}
+const mockLangToolCheck = vi.spyOn(languageToolService, "checkAll")
+
+async function renderComponent() {
+  return {
+    ...render(DocumentationUnitTextCheckSummary, {}),
+  }
+}
+
+describe("Documentation Text Check Summary", () => {
+  beforeEach(async () => {
+    setActivePinia(createTestingPinia())
+    mockLangToolCheck.mockResolvedValue(checkAllResponse)
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it("updates Document Unit before initiating check all", async () => {
+    const mockedStore = useDocumentUnitStore()
+    mockedStore.documentUnit = new Decision("test-uuid", {})
+    mockedStore.updateDocumentUnit = vi.fn().mockResolvedValue(undefined)
+
+    await renderComponent()
+
+    expect(mockedStore.updateDocumentUnit).toHaveBeenCalledBefore(
+      mockLangToolCheck,
+    )
+  })
+
+  it("nothing is checked or updated if documentUnit not in store", async () => {
+    const mockedStore = useDocumentUnitStore()
+    mockedStore.documentUnit = undefined
+
+    await renderComponent()
+
+    expect(mockedStore.updateDocumentUnit).toHaveBeenCalledTimes(0)
+    expect(mockLangToolCheck).toHaveBeenCalledTimes(0)
+  })
+})


### PR DESCRIPTION
There was a bug when navigating to jDV when a check of the whole document was done, the bug was that when the user manually changed an incorrect word the change was not registered in time and the error was reported in the total errors count. Now the document is updated/patched before the check and now the total number of errors is correct.