### PR TITLE
[RISDEV-9094] Fix sync bug

### DIFF
--- a/frontend/src/components/HandoverDecisionView.vue
+++ b/frontend/src/components/HandoverDecisionView.vue
@@ -1,7 +1,7 @@
 <script lang="ts" setup>
 import { storeToRefs } from "pinia"
 import Button from "primevue/button"
-import { computed, onMounted, Ref, ref } from "vue"
+import { computed, onBeforeMount, Ref, ref } from "vue"
 import { RouterLink } from "vue-router"
 import ExpandableContent from "./ExpandableContent.vue"
 import CodeSnippet from "@/components/CodeSnippet.vue"
@@ -74,7 +74,7 @@ const errorMessage = computed(
   () => frontendError.value ?? previewError.value ?? props.errorMessage,
 )
 
-onMounted(async () => {
+onBeforeMount(async () => {
   // Save doc unit in case there are any unsaved local changes before fetching xml preview
   await store.updateDocumentUnit()
 

--- a/frontend/src/components/text-check/HandoverTextCheckView.vue
+++ b/frontend/src/components/text-check/HandoverTextCheckView.vue
@@ -7,6 +7,7 @@ import LoadingSpinner from "@/components/LoadingSpinner.vue"
 import router from "@/router"
 import { ResponseError } from "@/services/httpClient"
 import languageToolService from "@/services/textCheckService"
+import { useDocumentUnitStore } from "@/stores/documentUnitStore"
 import IconCheck from "~icons/ic/baseline-check"
 import IconErrorOutline from "~icons/ic/baseline-error-outline"
 
@@ -19,6 +20,8 @@ const responseError = ref<ResponseError | undefined>()
 
 const loading = ref()
 const totalTextCheckErrors = ref(0)
+const store = useDocumentUnitStore()
+
 const textCategories = ref<string[] | undefined>()
 
 async function navigateToTextCheckSummaryInCategories() {
@@ -59,6 +62,7 @@ const textCategoriesRouter = (category: string) => ({
 })
 
 onBeforeMount(async () => {
+  await store.updateDocumentUnit()
   await checkAll(props.documentId)
 })
 </script>

--- a/frontend/test/e2e/caselaw/utils/documentation-unit-api-util.ts
+++ b/frontend/test/e2e/caselaw/utils/documentation-unit-api-util.ts
@@ -21,6 +21,24 @@ export async function updateDocumentationUnit(
   )
 }
 
+export async function patchDocumentationUnit(
+  page: Page,
+  documentUnit: Decision,
+  request: APIRequestContext,
+): Promise<APIResponse> {
+  const cookies = await page.context().cookies()
+  const csrfToken = cookies.find((cookie) => cookie.name === "XSRF-TOKEN")
+  return await request.patch(
+    `/api/v1/caselaw/documentunits/${documentUnit.uuid}`,
+    {
+      data: {
+        ...documentUnit,
+      },
+      headers: { "X-XSRF-TOKEN": csrfToken?.value ?? "" },
+    },
+  )
+}
+
 export async function addIgnoreWordToDocumentationUnit(
   page: Page,
   uuid: string,


### PR DESCRIPTION
When user would navigate to overview page without saving then the error count would not show correct values because it seemed like save lasted longer than expected.
But the case was that the wrong component was being "fixed".