### PR TITLE
Fix email address in /auth/me endpoint

### DIFF
--- a/backend/src/main/java/de/bund/digitalservice/ris/caselaw/adapter/DatabaseUserService.java
+++ b/backend/src/main/java/de/bund/digitalservice/ris/caselaw/adapter/DatabaseUserService.java
@@ -68,10 +68,19 @@ public class DatabaseUserService extends UserService {
    */
   @Override
   public User getUser(OidcUser oidcUser) {
-    return userRepository
-        .findByExternalId(UserTransformer.getOidcUserId(oidcUser))
-        .orElseGet(
-            () -> userRepository.saveOrUpdate(keycloakUserService.getUser(oidcUser)).orElse(null));
+    User user =
+        userRepository
+            .findByExternalId(UserTransformer.getOidcUserId(oidcUser))
+            .orElseGet(
+                () ->
+                    userRepository
+                        .saveOrUpdate(keycloakUserService.getUser(oidcUser))
+                        .orElse(null));
+    /* The email address is currently needed for the scheduled publication. It is not yet part of the user table,
+    so we add it via the oidc user here, so that the /auth/me endpoint returns the email address.
+    In the future, this should be removed again and either the email address added to the user table
+    or the need for email addresses / notifications replaced */
+    return user != null ? user.toBuilder().email(oidcUser.getEmail()).build() : null;
   }
 
   /**

--- a/backend/src/test/java/de/bund/digitalservice/ris/caselaw/integration/tests/AuthIntegrationTest.java
+++ b/backend/src/test/java/de/bund/digitalservice/ris/caselaw/integration/tests/AuthIntegrationTest.java
@@ -24,6 +24,7 @@ class AuthIntegrationTest extends BaseIntegrationTest {
         .consumeWith(
             response -> {
               assertThat(response.getResponseBody().name()).isEqualTo("testUser");
+              assertThat(response.getResponseBody().email()).isEqualTo("test@test.com");
               assertThat(response.getResponseBody().documentationOffice().abbreviation())
                   .isEqualTo("DS");
             });


### PR DESCRIPTION
RISDEV-9542
RISUP-481

The mail address is needed for the scheduled publication. This is only a hotfix and should be fixed properly at a later point.